### PR TITLE
Drop unused pytest dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 flake8==3.6.0
 pycodestyle==2.4.0
 pyflakes==2.0.0
-pytest==5.0.1
 pep8-naming==0.11.1


### PR DESCRIPTION
It's not even a transitive dependency of flake8, which is the only
Python depedency used directly in this repositories. (The other
dependencies are dependencies of flake8.)