### PR TITLE
Convert from requirements.txt to pipenv's Pipfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,9 @@ jobs:
       with:
         python-version: '3.6'
     - name: Install Python dependencies
-      run: pip install -r requirements.txt
+      run: pip install pipenv && pipenv install --dev
     - name: flake8
-      run: flake8 src test
+      run: pipenv run flake8
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,6 @@
 HOST=gcr.io
 PROJECT_ID=wpt-live
 
-.PHONY: test
-test: test-lint
-
-.PHONY: test-lint
-test-lint:
-	terraform fmt --check
-	flake8 src test
-
 .PHONY: cert-renewer wpt-server-tot
 cert-renewer wpt-server-tot:
 	docker build \

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,8 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+flake8 = "==3.9.1"
+pep8-naming = "==0.11.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,65 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "9898ee353309119beb2f591d4727d18e775170cce66e01b7fa83c3ac74125506"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "flake8": {
+            "hashes": [
+                "sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378",
+                "sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a"
+            ],
+            "index": "pypi",
+            "version": "==3.9.1"
+        },
+        "flake8-polyfill": {
+            "hashes": [
+                "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9",
+                "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
+            ],
+            "version": "==1.0.2"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pep8-naming": {
+            "hashes": [
+                "sha256:a1dd47dd243adfe8a83616e27cf03164960b507530f155db94e10b36a6cd6724",
+                "sha256:f43bfe3eea7e0d73e8b5d07d6407ab47f2476ccaeff6937c84275cd30b016738"
+            ],
+            "index": "pypi",
+            "version": "==0.11.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
+                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.7.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
+                "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.3.1"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Running these containers requires the specification of a number of environment
 variables. See the appropriate `Dockerfile` for a definition of the expected
 variables.
 
+## Linting
+
+Requirements:
+
+- [Python 3](https://python.org)
+- [Pipenv](https://pipenv.pypa.io/)
+- [Terraform](https://www.terraform.io/) version 0.11.14
+
+The following commands will run the lints:
+
+    pipenv install --dev
+    pipenv run flake8
+    terraform fmt --check
+
 ## Deploying
 
 Requirements:

--- a/infrastructure/docker-image/latest-image.py
+++ b/infrastructure/docker-image/latest-image.py
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import sys
 import urllib.request
 
 
@@ -14,9 +13,10 @@ def main(registry, image):
     }
 
     with urllib.request.urlopen(url) as contents:
-        for identifier, metadata in json.load(contents).get('manifest').items():
+        manifest = json.load(contents).get('manifest')
+        for identifier, metadata in manifest.items():
             time_created = int(metadata.get('timeCreatedMs'))
-            if  time_created > latest['time_created']:
+            if time_created > latest['time_created']:
                 latest['identifier'] = identifier
                 latest['time_created'] = time_created
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-flake8==3.6.0
-pycodestyle==2.4.0
-pyflakes==2.0.0
-pytest==5.0.1
-pep8-naming==0.11.1


### PR DESCRIPTION
This makes it much clearer what our own dependencies are and which are
transitive dependencies.

Upgrade flake8 to make it actually work on Python 3.8 locally, and lint
all of the Python code, fixing the errors that remained.

Closes https://github.com/web-platform-tests/wpt.live/pull/46.