### PR TITLE
[Part 1/3] Upgrade terraform from 0.11.14 to 1.2.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: '0.11.14'
+        terraform_version: '1.2.5'
     - name: terraform
       run: terraform fmt --check

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.2.2"
+  hashes = [
+    "h1:e7RpnZ2PbJEEPnfsg7V0FNwbfSk0/Z3FdrLsXINBmDY=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.30.0"
+  hashes = [
+    "h1:6g4NhLzNgi8X2JE/ZLdKtS3Vth7jMCRDPNmcBYvoZgo=",
+    "zh:06baf0926f7654a1e4fda55f6319a88c1ac074c0429f38cba20435d59e3a0e74",
+    "zh:0c243ca97c0360602af08310534f14575ec373a76c908b67092ddb17db790eda",
+    "zh:1d77ceebcda0287fd7155e8da0fb5875a43be61b39cee5a7069874914b6deb00",
+    "zh:3fadc3d63ceb84068307e578434f35aff1c14814641bd96014a13da5c30e4391",
+    "zh:674882303e37fc88b287d1f4d4a3f39d767b5f3c067bd1ac05655e4548fdac6f",
+    "zh:70a18212af02fd7e537062bd6efd59c738d805e8a7e4d362ce06982ada4db076",
+    "zh:7fc9fa630c4f52f5ecaa12bb9f4af5e47b4720f5c453b46614242964a1f48839",
+    "zh:af87c19cfc56c8017ee2daab5e948550fd812a2a20aff7259c749894fde72952",
+    "zh:bd36b8892e6d77007e436d373c30fd36aee7afcf13fee19254b2491471f65e73",
+    "zh:d0b3e6d3bae5a68dda5607b04413027d612fd117f4dd7762f69b5db101524ca1",
+    "zh:eba24876922d1db24c51c619588299f50e2a661ac6fe4852cf037a44cff81d7b",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Requirements:
 
 - [Python 3](https://python.org)
 - [Pipenv](https://pipenv.pypa.io/)
-- [Terraform](https://www.terraform.io/) version 0.11.14
+- [Terraform](https://www.terraform.io/) version 1.2.5
 
 The following commands will run the lints:
 
@@ -153,7 +153,7 @@ Requirements:
 
 - [Docker](https://www.docker.com/)
 - [GNU Make](https://www.gnu.org/software/make/)
-- [Terraform](https://www.terraform.io/) version 0.11.14
+- [Terraform](https://www.terraform.io/) version 1.2.5
 - [Python 3](https://python.org)
 - access credentials to the Google Cloud Platform project, saved to a file named
   `google-cloud-platform-credentials.json` in the root pf this repository

--- a/infrastructure/docker-image/main.tf
+++ b/infrastructure/docker-image/main.tf
@@ -1,11 +1,11 @@
 variable "registry" {
   description = "Host name of the Docker registry from which the image identifier should be retirieved"
-  type        = "string"
+  type        = string
 }
 
 variable "image" {
   description = "Name of the Docker image whose identifier should be retrieved"
-  type        = "string"
+  type        = string
 }
 
 output "identifier" {
@@ -17,8 +17,8 @@ data "external" "image" {
     "python3",
     "${path.module}/latest-image.py",
     "--registry",
-    "${var.registry}",
+    var.registry,
     "--image",
-    "${var.image}",
+    var.image,
   ]
 }

--- a/infrastructure/docker-image/versions.tf
+++ b/infrastructure/docker-image/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = "~> 1.2.5"
+  required_providers {
+    external = {
+      source = "hashicorp/external"
+    }
+  }
+}

--- a/infrastructure/web-platform-tests/compute.tf
+++ b/infrastructure/web-platform-tests/compute.tf
@@ -1,0 +1,291 @@
+# Contains the configurations for the Compute Engine section of Google Cloud
+# These configurations come from modules that are now archived:
+# - Cert Renewer used: github.com/dcaba/terraform-google-managed-instance-group
+# - WPT Server used: github.com/ecosystem-infra/terraform-google-multi-port-managed-instance-group
+# Most hardcoded defaults come from those aforementioned modules.
+
+########################################
+# WPT Server
+# These configurations come from: github.com/ecosystem-infra/terraform-google-multi-port-managed-instance-group
+# More information about how it was used previously: https://github.com/web-platform-tests/wpt.live/blob/67dc5976ccce2e64483f2028a35659d4d6e58891/infrastructure/web-platform-tests/main.tf#L69-L137
+########################################
+
+resource "google_compute_health_check" "wpt_health_check" {
+  name = "${var.name}-wpt-servers"
+
+  check_interval_sec  = 10
+  timeout_sec         = 10
+  healthy_threshold   = 3
+  unhealthy_threshold = 6
+
+  https_health_check {
+    port = "443"
+    # A query parameter is used to distinguish the health check in the server's
+    # request logs.
+    request_path = "/?gcp-health-check"
+  }
+}
+
+resource "google_compute_instance_group_manager" "wpt_servers" {
+  name               = "${var.name}-wpt-servers"
+  zone               = var.zone
+  description        = "compute VM Instance Group"
+  wait_for_instances = false
+  base_instance_name = "${var.name}-wpt-servers"
+  version {
+    name              = "${var.name}-wpt-servers-default"
+    instance_template = google_compute_instance_template.wpt_server.self_link
+  }
+  update_policy {
+    type                  = local.update_policy.type
+    minimal_action        = local.update_policy.minimal_action
+    max_unavailable_fixed = local.update_policy.max_unavailable_fixed
+  }
+  target_pools = [google_compute_target_pool.default.self_link]
+  target_size  = 2
+
+  dynamic "named_port" {
+    for_each = var.wpt_server_ports
+    content {
+      name = named_port.value["name"]
+      port = named_port.value["port"]
+    }
+  }
+
+  auto_healing_policies {
+    health_check      = google_compute_health_check.wpt_health_check.self_link
+    initial_delay_sec = 30
+  }
+}
+
+resource "google_compute_firewall" "wpt-server-mig-health-check" {
+  name    = "${var.name}-wpt-servers-vm-hc"
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    # https port
+    ports = [var.wpt_server_ports[2].port]
+  }
+
+  # This range comes from this module that was used previously:
+  # https://github.com/Ecosystem-Infra/terraform-google-multi-port-managed-instance-group/blob/master/main.tf#L347
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["${var.name}-allow"]
+}
+
+resource "google_compute_firewall" "wpt-servers-default-ssh" {
+  name    = "${var.name}-wpt-servers-vm-ssh"
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-ssh"]
+}
+
+resource "google_compute_instance_template" "wpt_server" {
+  name_prefix = "default-"
+
+  tags = ["allow-ssh", "${var.name}-allow"]
+
+  # As of 2020-06-17, we were running into OOM issues with the 1.7 GB
+  # "g1-small" instance[1]. This was suspected to be due to 'git gc' needing
+  # more memory, so we upgraded to "e2-medium" (4 GB of RAM).
+  #
+  # [1] https://github.com/web-platform-tests/wpt.live/issues/30
+  machine_type = "e2-medium"
+
+  # The "google-logging-enabled" metadata is undocumented, but it is apparently
+  # necessary to enable the capture of logs from the Docker image.
+  #
+  # https://github.com/GoogleCloudPlatform/konlet/issues/56
+  labels = {
+    "${module.wpt-server-container.vm_container_label_key}" = module.wpt-server-container.vm_container_label
+  }
+
+  network_interface {
+    network    = var.network_name
+    subnetwork = var.subnetwork_name
+    access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+
+  can_ip_forward = false
+
+  // Create a new boot disk from an image
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = module.wpt-server-container.source_image
+    type         = "PERSISTENT"
+    disk_type    = "pd-ssd"
+    disk_size_gb = var.wpt_server_disk_size
+    mode         = "READ_WRITE"
+  }
+
+  service_account {
+    email  = "default"
+    scopes = ["storage-ro", "logging-write"]
+  }
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  # startup-script and tf_depends_id comes from the module previously used for wpt-server. (see link at top)
+  # TODO: evaluate if those two should be removed.
+  metadata = {
+    # "${module.wpt-server-container.metadata_key}" = module.wpt-server-container.metadata_value
+    # The value for ${module.wpt-server-container.metadata_key} is temporary. During the upgrade, the metadata rendering changes.
+    # More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/master/docs/upgrading_to_v2.0.md
+    # Clarification to the linked docs, metadata changes will destroy the old template and create a new one.
+    # In order to make this as smooth as possible, we will hardcode this.
+    # When ready, remove this temporary metadata and the one on cert-renewer. And uncomment the line above.
+    "${module.wpt-server-container.metadata_key}" = <<-EOT
+              ---
+              spec:
+                containers:
+                - env:
+                  - name: WPT_HOST
+                    value: wpt.live
+                  - name: WPT_ALT_HOST
+                    value: not-wpt.live
+                  - name: WPT_BUCKET
+                    value: wpt-tot-certificates
+                  image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe
+                restartPolicy: Always
+                volumes: []
+              EOT
+    "startup-script"                              = ""
+    "tf_depends_id"                               = ""
+    "google-logging-enabled"                      = "true"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+########################################
+# Cert Renewers
+# These configurations come from: github.com/dcaba/terraform-google-managed-instance-group
+# More information about how it was used previously: https://github.com/web-platform-tests/wpt.live/blob/67dc5976ccce2e64483f2028a35659d4d6e58891/infrastructure/web-platform-tests/main.tf#L139-L178
+########################################
+
+resource "google_compute_instance_template" "cert_renewers" {
+  name_prefix = "default-"
+
+  machine_type = "f1-micro"
+
+  region = var.region
+
+  tags = ["allow-ssh", "${var.name}-allow"]
+
+  labels = {
+    "${module.cert-renewer-container.vm_container_label_key}" = module.cert-renewer-container.vm_container_label
+  }
+
+  network_interface {
+    network    = var.network_name
+    subnetwork = var.subnetwork_name
+    network_ip = ""
+    access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+
+  can_ip_forward = false
+
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = module.cert-renewer-container.source_image
+    type         = "PERSISTENT"
+    disk_type    = "pd-ssd"
+    mode         = "READ_WRITE"
+  }
+
+  service_account {
+    email  = "default"
+    scopes = ["cloud-platform"]
+  }
+
+  # startup-script and tf_depends_id comes from the module previously used for cert renewer. (see link at top)
+  # TODO: evaluate if those two should be removed.
+  metadata = {
+    # "${module.cert-renewer-container.metadata_key}" = module.cert-renewer-container.metadata_value
+    # The value for ${module.cert-renewer-container.metadata_key} is temporary. During the upgrade, the metadata rendering changes.
+    # More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/master/docs/upgrading_to_v2.0.md
+    # Clarification to the linked docs, metadata changes will destroy the old template and create a new one.
+    # In order to make this as smooth as possible, we will hardcode this.
+    # When ready, remove this temporary metadata and the one on wpt-server. And uncomment the line above.
+    "${module.cert-renewer-container.metadata_key}" = <<-EOT
+              ---
+              spec:
+                containers:
+                - env:
+                  - name: WPT_HOST
+                    value: wpt.live
+                  - name: WPT_ALT_HOST
+                    value: not-wpt.live
+                  - name: WPT_BUCKET
+                    value: wpt-tot-certificates
+                  image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5
+                restartPolicy: Always
+                volumes: []
+              EOT
+    "startup-script"                                = ""
+    "tf_depends_id"                                 = ""
+    "google-logging-enabled"                        = "true"
+  }
+
+  scheduling {
+    preemptible         = false
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "cert_renewers" {
+  name               = "${var.name}-cert-renewers"
+  description        = "compute VM Instance Group"
+  wait_for_instances = false
+
+  base_instance_name = "${var.name}-cert-renewers"
+
+  version {
+    instance_template = google_compute_instance_template.cert_renewers.self_link
+  }
+
+  zone = var.zone
+
+  update_policy {
+    # The type is different from wpt servers's update policy.
+    # TODO: Evaluate why
+    type                  = "OPPORTUNISTIC"
+    minimal_action        = local.update_policy.minimal_action
+    max_unavailable_fixed = local.update_policy.max_unavailable_fixed
+  }
+
+  target_pools = []
+
+  target_size = 1
+
+  dynamic "named_port" {
+    for_each = var.cert_renewer_ports
+    content {
+      name = named_port.value["name"]
+      port = named_port.value["port"]
+    }
+  }
+}

--- a/infrastructure/web-platform-tests/load-balancing.tf
+++ b/infrastructure/web-platform-tests/load-balancing.tf
@@ -7,33 +7,25 @@
 locals {
   lb_name = "${var.name}-load-balancing"
 
-  forwarded_ports = [
-    "${module.wpt-servers.service_port_1}",
-    "${module.wpt-servers.service_port_2}",
-    "${module.wpt-servers.service_port_3}",
-    "${module.wpt-servers.service_port_4}",
-    "${module.wpt-servers.service_port_5}",
-    "${module.wpt-servers.service_port_6}",
-    "${module.wpt-servers.service_port_7}",
-  ]
+  forwarded_ports = [for wpt_server_port in var.wpt_server_ports : wpt_server_port.port]
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  count                 = "${length(local.forwarded_ports)}"
+  count                 = length(local.forwarded_ports)
   name                  = "${local.lb_name}-${count.index}"
-  target                = "${google_compute_target_pool.default.self_link}"
+  target                = google_compute_target_pool.default.self_link
   load_balancing_scheme = "EXTERNAL"
-  port_range            = "${local.forwarded_ports[count.index]}"
-  ip_address            = "${google_compute_address.web-platform-tests-live-address.address}"
+  port_range            = local.forwarded_ports[count.index]
+  ip_address            = google_compute_address.web-platform-tests-live-address.address
 }
 
 resource "google_compute_target_pool" "default" {
-  name             = "${local.lb_name}"
-  region           = "${var.region}"
+  name             = local.lb_name
+  region           = var.region
   session_affinity = "CLIENT_IP_PROTO"
 
   health_checks = [
-    "${google_compute_http_health_check.default.name}",
+    google_compute_http_health_check.default.name,
   ]
 }
 
@@ -44,18 +36,18 @@ resource "google_compute_http_health_check" "default" {
   # request logs.
   request_path = "/?gcp-health-check-load-balancing"
 
-  port = "${module.wpt-servers.service_port_1}"
+  port = var.wpt_server_ports[0].port
 }
 
 resource "google_compute_firewall" "default-lb-fw" {
   name    = "${local.lb_name}-vm-service"
-  network = "${var.network_name}"
+  network = var.network_name
 
   allow {
     protocol = "tcp"
-    ports    = "${local.forwarded_ports}"
+    ports    = local.forwarded_ports
   }
 
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["${module.wpt-servers.target_tags}"]
+  target_tags   = ["${var.name}-allow"]
 }

--- a/infrastructure/web-platform-tests/main.tf
+++ b/infrastructure/web-platform-tests/main.tf
@@ -1,39 +1,36 @@
-# https://github.com/hashicorp/terraform/issues/17399
-provider "google-beta" {}
-
 locals {
   bucket_name = "${var.name}-certificates"
 
-  update_policy = [
-    {
-      type           = "PROACTIVE"
-      minimal_action = "RESTART"
+  update_policy = {
+    type           = "PROACTIVE"
+    minimal_action = "RESTART"
+    # > maxUnavailable must be greater than 0 when minimal action is set to
+    # > RESTART
+    max_unavailable_fixed = 1
+  }
 
-      # > maxUnavailable must be greater than 0 when minimal action is set to
-      # > RESTART
-      max_unavailable_fixed = 1
-    },
-  ]
 }
 
 module "wpt-server-container" {
-  source = "github.com/terraform-google-modules/terraform-google-container-vm?ref=v0.3.0"
+  source  = "terraform-google-modules/container-vm/google"
+  version = "3.0.0"
 
+  # Temporary variable
+  cos_image_name = var.cos_image_name
   container = {
-    image = "${var.wpt_server_image}"
-
+    image = var.wpt_server_image
     env = [
       {
         name  = "WPT_HOST"
-        value = "${var.host_name}"
+        value = var.host_name
       },
       {
         name  = "WPT_ALT_HOST"
-        value = "${var.alt_host_name}"
+        value = var.alt_host_name
       },
       {
         name  = "WPT_BUCKET"
-        value = "${local.bucket_name}"
+        value = local.bucket_name
       },
     ]
   }
@@ -42,23 +39,25 @@ module "wpt-server-container" {
 }
 
 module "cert-renewer-container" {
-  source = "github.com/terraform-google-modules/terraform-google-container-vm?ref=v0.3.0"
+  source  = "terraform-google-modules/container-vm/google"
+  version = "3.0.0"
 
+  # Temporary variable
+  cos_image_name = var.cos_image_name
   container = {
-    image = "${var.cert_renewer_image}"
-
+    image = var.cert_renewer_image
     env = [
       {
         name  = "WPT_HOST"
-        value = "${var.host_name}"
+        value = var.host_name
       },
       {
         name  = "WPT_ALT_HOST"
-        value = "${var.alt_host_name}"
+        value = var.alt_host_name
       },
       {
         name  = "WPT_BUCKET"
-        value = "${local.bucket_name}"
+        value = local.bucket_name
       },
     ]
   }
@@ -66,117 +65,7 @@ module "cert-renewer-container" {
   restart_policy = "Always"
 }
 
-module "wpt-servers" {
-  source = "github.com/ecosystem-infra/terraform-google-multi-port-managed-instance-group?ref=a40a3b9f3"
-
-  providers {
-    google-beta = "google-beta"
-  }
-
-  region        = "${var.region}"
-  zone          = "${var.zone}"
-  name          = "${var.name}-wpt-servers"
-  size          = 2
-  compute_image = "${module.wpt-server-container.source_image}"
-
-  # As of 2020-06-17, we were running into OOM issues with the 1.7 GB
-  # "g1-small" instance[1]. This was suspected to be due to 'git gc' needing
-  # more memory, so we upgraded to "e2-medium" (4 GB of RAM).
-  #
-  # [1] https://github.com/web-platform-tests/wpt.live/issues/30
-  machine_type = "e2-medium"
-
-  instance_labels = "${map(
-    module.wpt-server-container.vm_container_label_key,
-    module.wpt-server-container.vm_container_label
-  )}"
-
-  # The "google-logging-enabled" metadata is undocumented, but it is apparently
-  # necessary to enable the capture of logs from the Docker image.
-  #
-  # https://github.com/GoogleCloudPlatform/konlet/issues/56
-  metadata = "${map(
-    module.wpt-server-container.metadata_key,
-    module.wpt-server-container.metadata_value,
-    "google-logging-enabled",
-    "true"
-  )}"
-
-  service_port_1      = 80
-  service_port_1_name = "http-primary"
-  service_port_2      = 8000
-  service_port_2_name = "http-secondary"
-  service_port_3      = 443
-  service_port_3_name = "https"
-  service_port_4      = 8001
-  service_port_4_name = "http2"
-  service_port_5      = 8002
-  service_port_5_name = "websocket"
-  service_port_6      = 8003
-  service_port_6_name = "websocket-secure"
-  service_port_7      = 8443
-  service_port_7_name = "https-secondary"
-  ssh_fw_rule         = true
-  https_health_check  = true
-
-  # A query parameter is used to distinguish the health check in the server's
-  # request logs.
-  hc_path = "/?gcp-health-check"
-
-  hc_port                = 443
-  hc_interval            = 10
-  hc_healthy_threshold   = 3
-  hc_unhealthy_threshold = 6
-  target_pools           = ["${google_compute_target_pool.default.self_link}"]
-  target_tags            = ["${var.name}-allow"]
-  network                = "${var.network_name}"
-  subnetwork             = "${var.subnetwork_name}"
-  service_account_scopes = ["storage-ro", "logging-write"]
-  update_policy          = "${local.update_policy}"
-  disk_size_gb           = "${var.wpt_server_disk_size}"
-}
-
-module "cert-renewers" {
-  # https://github.com/GoogleCloudPlatform/terraform-google-managed-instance-group/pull/39
-  source = "github.com/dcaba/terraform-google-managed-instance-group?ref=340409c"
-
-  providers {
-    google-beta = "google-beta"
-  }
-
-  region        = "${var.region}"
-  zone          = "${var.zone}"
-  name          = "${var.name}-cert-renewers"
-  size          = 1
-  compute_image = "${module.cert-renewer-container.source_image}"
-
-  instance_labels = "${map(
-    module.cert-renewer-container.vm_container_label_key,
-    module.cert-renewer-container.vm_container_label
-  )}"
-
-  # The "google-logging-enabled" metadata is undocumented, but it is apparently
-  # necessary to enable the capture of logs from the Docker image.
-  #
-  # https://github.com/GoogleCloudPlatform/konlet/issues/56
-  metadata = "${map(
-    module.cert-renewer-container.metadata_key,
-    module.cert-renewer-container.metadata_value,
-    "google-logging-enabled",
-    "true"
-  )}"
-
-  service_port           = 8004
-  service_port_name      = "http"
-  ssh_fw_rule            = false
-  http_health_check      = false
-  target_tags            = ["${var.name}-allow"]
-  network                = "${var.network_name}"
-  subnetwork             = "${var.subnetwork_name}"
-  service_account_scopes = ["cloud-platform"]
-  update_policy          = "${local.update_policy}"
-}
-
 resource "google_storage_bucket" "certificates" {
-  name = "${local.bucket_name}"
+  name     = local.bucket_name
+  location = "US"
 }

--- a/infrastructure/web-platform-tests/networking.tf
+++ b/infrastructure/web-platform-tests/networking.tf
@@ -3,17 +3,17 @@ resource "google_compute_address" "web-platform-tests-live-address" {
 }
 
 data "google_dns_managed_zone" "host" {
-  name = "${var.host_zone_name}"
+  name = var.host_zone_name
 }
 
 resource "google_dns_record_set" "host_bare" {
-  name = "${data.google_dns_managed_zone.host.dns_name}"
+  name = data.google_dns_managed_zone.host.dns_name
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.host.name}"
+  managed_zone = data.google_dns_managed_zone.host.name
 
-  rrdatas = ["${google_compute_address.web-platform-tests-live-address.address}"]
+  rrdatas = [google_compute_address.web-platform-tests-live-address.address]
 }
 
 resource "google_dns_record_set" "host_subdomains" {
@@ -21,9 +21,9 @@ resource "google_dns_record_set" "host_subdomains" {
   type = "CNAME"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.host.name}"
+  managed_zone = data.google_dns_managed_zone.host.name
 
-  rrdatas = ["${data.google_dns_managed_zone.host.dns_name}"]
+  rrdatas = [data.google_dns_managed_zone.host.dns_name]
 }
 
 resource "google_dns_record_set" "host_nonexistent_subdomains" {
@@ -31,23 +31,23 @@ resource "google_dns_record_set" "host_nonexistent_subdomains" {
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.host.name}"
+  managed_zone = data.google_dns_managed_zone.host.name
 
   rrdatas = ["0.0.0.0"]
 }
 
 data "google_dns_managed_zone" "alt_host" {
-  name = "${var.alt_host_zone_name}"
+  name = var.alt_host_zone_name
 }
 
 resource "google_dns_record_set" "alt_host_bare" {
-  name = "${data.google_dns_managed_zone.alt_host.dns_name}"
+  name = data.google_dns_managed_zone.alt_host.dns_name
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.alt_host.name}"
+  managed_zone = data.google_dns_managed_zone.alt_host.name
 
-  rrdatas = ["${google_compute_address.web-platform-tests-live-address.address}"]
+  rrdatas = [google_compute_address.web-platform-tests-live-address.address]
 }
 
 resource "google_dns_record_set" "alt_host_subdomains" {
@@ -55,9 +55,9 @@ resource "google_dns_record_set" "alt_host_subdomains" {
   type = "CNAME"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.alt_host.name}"
+  managed_zone = data.google_dns_managed_zone.alt_host.name
 
-  rrdatas = ["${data.google_dns_managed_zone.alt_host.dns_name}"]
+  rrdatas = [data.google_dns_managed_zone.alt_host.dns_name]
 }
 
 resource "google_dns_record_set" "alt_host_nonexistent_subdomains" {
@@ -65,7 +65,7 @@ resource "google_dns_record_set" "alt_host_nonexistent_subdomains" {
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.alt_host.name}"
+  managed_zone = data.google_dns_managed_zone.alt_host.name
 
   rrdatas = ["0.0.0.0"]
 }

--- a/infrastructure/web-platform-tests/outputs.tf
+++ b/infrastructure/web-platform-tests/outputs.tf
@@ -1,3 +1,3 @@
 output "address" {
-  value = "${google_compute_address.web-platform-tests-live-address.address}"
+  value = google_compute_address.web-platform-tests-live-address.address
 }

--- a/infrastructure/web-platform-tests/variables.tf
+++ b/infrastructure/web-platform-tests/variables.tf
@@ -1,52 +1,111 @@
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "zone" {
-  type = "string"
+  type = string
 }
 
 variable "name" {
-  type = "string"
+  type = string
 }
 
 variable "network_name" {
-  type = "string"
+  type = string
 }
 
 variable "subnetwork_name" {
-  type = "string"
+  type = string
 }
 
 variable "host_zone_name" {
-  type        = "string"
+  type        = string
   description = "The primary host to be used by the web-platform-tests server"
 }
 
 variable "host_name" {
-  type = "string"
+  type = string
 }
 
 variable "alt_host_zone_name" {
-  type        = "string"
+  type        = string
   description = "The secondary host to be used by the web-platform-tests server"
 }
 
 variable "alt_host_name" {
-  type = "string"
+  type = string
 }
 
 variable "wpt_server_image" {
-  type        = "string"
+  type        = string
   description = "The address of a Docker image that runs the web-platform-tests server"
 }
 
 variable "cert_renewer_image" {
-  type        = "string"
+  type        = string
   description = "The address of of a Docker image that renews TLS certificates for the system"
 }
 
 variable "wpt_server_disk_size" {
   description = "The size of the disk in gigabytes. If not specified, it will inherit the size of its base image."
   default     = 0
+}
+
+variable "wpt_server_ports" {
+  type = list(object({
+    name = string
+    port = number
+  }))
+  description = "Mapping of name to port. Ports are used for the wpt server."
+  default = [
+    {
+      name = "http-primary",
+      port = 80
+    },
+    {
+      name = "http-secondary",
+      port = 8000
+    },
+    {
+      name = "https",
+      port = 443
+    },
+    {
+      name = "http2",
+      port = 8001
+    },
+    {
+      name = "websocket",
+      port = 8002
+    },
+    {
+      name = "websocket-secure",
+      port = 8003
+    },
+    {
+      name = "https-secondary",
+      port = 8443
+    },
+  ]
+}
+
+
+variable "cert_renewer_ports" {
+  type = list(object({
+    name = string
+    port = number
+  }))
+  description = "Mapping of name to port. Ports are used for the cert renewer."
+  default = [
+    {
+      name = "http",
+      port = 8004
+    }
+  ]
+}
+
+variable "cos_image_name" {
+  description = "Name of specific COS image. Temporary variable. Will remove here and in main.tf once ready to upgrade. More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/5e69eafaaaa8302c5732799e32d1da5c17b7b285/variables.tf#L46"
+  type        = string
+  default     = "cos-stable-85-13310-1209-17"
 }

--- a/infrastructure/web-platform-tests/versions.tf
+++ b/infrastructure/web-platform-tests/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = "~> 1.2.5"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -5,15 +5,9 @@ locals {
 }
 
 provider "google" {
-  project     = "${local.project_name}"
-  region      = "${local.region}"
-  credentials = "${file("google-cloud-platform-credentials.json")}"
-}
-
-provider "google-beta" {
-  project     = "${local.project_name}"
-  region      = "${local.region}"
-  credentials = "${file("google-cloud-platform-credentials.json")}"
+  project     = local.project_name
+  region      = local.region
+  credentials = file("google-cloud-platform-credentials.json")
 }
 
 resource "google_compute_network" "default" {
@@ -24,8 +18,8 @@ resource "google_compute_network" "default" {
 resource "google_compute_subnetwork" "default" {
   name                     = "wpt-live-subnetwork"
   ip_cidr_range            = "10.127.0.0/20"
-  network                  = "${google_compute_network.default.self_link}"
-  region                   = "${local.region}"
+  network                  = google_compute_network.default.self_link
+  region                   = local.region
   private_ip_google_access = true
 }
 
@@ -44,24 +38,21 @@ module "cert-renewer-image" {
 module "wpt-live" {
   source = "./infrastructure/web-platform-tests"
 
-  providers {
-    google-beta = "google-beta"
-  }
-
   name               = "wpt-tot"
-  network_name       = "${google_compute_network.default.name}"
-  subnetwork_name    = "${google_compute_subnetwork.default.name}"
+  network_name       = google_compute_network.default.name
+  subnetwork_name    = google_compute_subnetwork.default.name
   host_zone_name     = "wpt-live"
   host_name          = "wpt.live"
   alt_host_zone_name = "not-wpt-live"
   alt_host_name      = "not-wpt.live"
-  region             = "${local.region}"
-  zone               = "${local.zone}"
+  region             = local.region
+  zone               = local.zone
 
-  wpt_server_image   = "${module.wpt-server-tot-image.identifier}"
-  cert_renewer_image = "${module.cert-renewer-image.identifier}"
+  wpt_server_image   = module.wpt-server-tot-image.identifier
+  cert_renewer_image = module.cert-renewer-image.identifier
 }
 
 output "wpt-live-address" {
-  value = "${module.wpt-live.address}"
+  value = module.wpt-live.address
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = "~> 1.2.5"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}


### PR DESCRIPTION
## Why:
- Terraform 0.11.x is end of life [(1)](https://discuss.hashicorp.com/t/when-specifically-is-terraform-0-11-deprecated/3996/4) [(2)](https://www.hashicorp.com/blog/deprecating-terraform-0-11-support-in-terraform-providers)
- terraform rotated their signing [certificate](https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570). As a result `terraform init` fails. Instead, a user will need to use `terraform init -verify-plugins=false` if they want to maintain using 0.11.14. This is not safe. Version 0.11.15 has the new certificate. But the other reasons prevented from using that.
- The providers versions are not pinned. As a result, it pulls the latest that it can. Not sure if it was the one used initially.
- Resources used previously were in the google-beta provider. Now they
  are in the google stable provider.

More details: #61 

## Changes:
- Add .terraform.lock.hcl. This file is a lock file for terraform providers that this repo depends on. Only available in newer versions of terraform
- Syntax changes. Version 0.12 and onwards has a different syntax than
  0.11. Example:
  - `ports = "${local.forwarded_ports}` -> `ports = local.forwarded_ports`
  - These changes occured automatically leveraging [`terraform 0.12upgrade`](https://www.terraform.io/language/upgrade-guides/0-12#upgrading-terraform-configuration)
- various `versions.tf` files. These were generated when running [`terraform 0.13upgrade`](https://www.terraform.io/language/upgrade-guides/0-13#explicit-provider-source-locations)
- compute.tf: This file was added by me. Previously, this repo used two
  external modules: github.com/dcaba/terraform-google-managed-instance-group and github.com/ecosystem-infra/terraform-google-multi-port-managed-instance-group. However, these modules are not compatible with the new versions of terraform. One repo is archived and the other has not been touched in awhile. Those modules are using beta features which are now in the main google provider now. We can now just use the out of the box Google provider to build the same infrastructure.
- Upgrade the terraform-google-modules/container-vm/google module reference to latest.
- Removed references to the `google-beta` provider since it is not needed anymore
- Added placeholder "cos_image_name" which pins the OS image currently used. Otherwise, it will pick the latest and cause a difference to be detected. This will be removed in Part 3 (#60) .

## How were these changes tested:

Along with the changes in #59 , running `terraform plan` yielded no changes in the infrastructure after the terraform upgrade

<details><summary>Show Plan</summary>

```
module.cert-renewer-image.data.external.image: Reading...
module.wpt-server-tot-image.data.external.image: Reading...
module.cert-renewer-image.data.external.image: Read complete after 0s [id=-]
module.wpt-server-tot-image.data.external.image: Read complete after 0s [id=-]
module.wpt-live.data.google_dns_managed_zone.alt_host: Reading...
module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos: Reading...
module.wpt-live.google_compute_address.web-platform-tests-live-address: Refreshing state... [id=wpt-live/us-central1/wpt-tot-address]
module.wpt-live.google_storage_bucket.certificates: Refreshing state... [id=wpt-tot-certificates]
google_compute_network.default: Refreshing state... [id=wpt-live-network]
module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos: Reading...
module.wpt-live.data.google_dns_managed_zone.host: Reading...
module.wpt-live.google_compute_http_health_check.default: Refreshing state... [id=wpt-tot-load-balancing-health-check]
module.wpt-live.google_compute_health_check.wpt_health_check: Refreshing state... [id=wpt-tot-wpt-servers]
module.wpt-live.data.google_dns_managed_zone.host: Read complete after 0s [id=projects/wpt-live/managedZones/wpt-live]
module.wpt-live.google_dns_record_set.host_subdomains: Refreshing state... [id=wpt-live/*.wpt.live./CNAME]
module.wpt-live.data.google_dns_managed_zone.alt_host: Read complete after 0s [id=projects/wpt-live/managedZones/not-wpt-live]
module.wpt-live.google_dns_record_set.host_nonexistent_subdomains: Refreshing state... [id=wpt-live/nonexistent.wpt.live./A]
module.wpt-live.google_dns_record_set.alt_host_nonexistent_subdomains: Refreshing state... [id=not-wpt-live/nonexistent.not-wpt.live./A]
module.wpt-live.google_dns_record_set.alt_host_subdomains: Refreshing state... [id=not-wpt-live/*.not-wpt.live./CNAME]
module.wpt-live.google_dns_record_set.alt_host_bare: Refreshing state... [id=not-wpt-live/not-wpt.live./A]
module.wpt-live.google_dns_record_set.host_bare: Refreshing state... [id=wpt-live/wpt.live./A]
module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos: Read complete after 0s [id=projects/cos-cloud/global/images/cos-stable-85-13310-1209-17]
google_compute_subnetwork.default: Refreshing state... [id=us-central1/wpt-live-subnetwork]
module.wpt-live.google_compute_firewall.wpt-servers-default-ssh: Refreshing state... [id=wpt-tot-wpt-servers-vm-ssh]
module.wpt-live.google_compute_firewall.wpt-server-mig-health-check: Refreshing state... [id=wpt-tot-wpt-servers-vm-hc]
module.wpt-live.google_compute_firewall.default-lb-fw: Refreshing state... [id=wpt-tot-load-balancing-vm-service]
module.wpt-live.google_compute_target_pool.default: Refreshing state... [id=wpt-tot-load-balancing]
module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos: Read complete after 0s [id=projects/cos-cloud/global/images/cos-stable-85-13310-1209-17]
module.wpt-live.google_compute_instance_template.cert_renewers: Refreshing state... [id=default-20210315172233921500000001]
module.wpt-live.google_compute_instance_template.wpt_server: Refreshing state... [id=default-20210315172234903400000002]
module.wpt-live.google_compute_forwarding_rule.default[3]: Refreshing state... [id=wpt-tot-load-balancing-3]
module.wpt-live.google_compute_forwarding_rule.default[4]: Refreshing state... [id=wpt-tot-load-balancing-4]
module.wpt-live.google_compute_forwarding_rule.default[1]: Refreshing state... [id=wpt-tot-load-balancing-1]
module.wpt-live.google_compute_forwarding_rule.default[0]: Refreshing state... [id=wpt-tot-load-balancing-0]
module.wpt-live.google_compute_forwarding_rule.default[5]: Refreshing state... [id=wpt-tot-load-balancing-5]
module.wpt-live.google_compute_forwarding_rule.default[2]: Refreshing state... [id=wpt-tot-load-balancing-2]
module.wpt-live.google_compute_forwarding_rule.default[6]: Refreshing state... [id=wpt-tot-load-balancing-6]
module.wpt-live.google_compute_instance_group_manager.cert_renewers: Refreshing state... [id=wpt-live/us-central1-b/wpt-tot-cert-renewers]
module.wpt-live.google_compute_instance_group_manager.wpt_servers: Refreshing state... [id=wpt-live/us-central1-b/wpt-tot-wpt-servers]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

```

</details>


Outstanding changes:
- terraform.tfstate has changed the format over the versions. In order to make this PR readable, I separated that change into Part 2/3 (#59)