### PR TITLE
[Part 2/3] Add generated changes for terraform upgrade

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: '0.11.14'
+        terraform_version: '1.2.5'
     - name: terraform
       run: terraform fmt --check

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.2.2"
+  hashes = [
+    "h1:e7RpnZ2PbJEEPnfsg7V0FNwbfSk0/Z3FdrLsXINBmDY=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.30.0"
+  hashes = [
+    "h1:6g4NhLzNgi8X2JE/ZLdKtS3Vth7jMCRDPNmcBYvoZgo=",
+    "zh:06baf0926f7654a1e4fda55f6319a88c1ac074c0429f38cba20435d59e3a0e74",
+    "zh:0c243ca97c0360602af08310534f14575ec373a76c908b67092ddb17db790eda",
+    "zh:1d77ceebcda0287fd7155e8da0fb5875a43be61b39cee5a7069874914b6deb00",
+    "zh:3fadc3d63ceb84068307e578434f35aff1c14814641bd96014a13da5c30e4391",
+    "zh:674882303e37fc88b287d1f4d4a3f39d767b5f3c067bd1ac05655e4548fdac6f",
+    "zh:70a18212af02fd7e537062bd6efd59c738d805e8a7e4d362ce06982ada4db076",
+    "zh:7fc9fa630c4f52f5ecaa12bb9f4af5e47b4720f5c453b46614242964a1f48839",
+    "zh:af87c19cfc56c8017ee2daab5e948550fd812a2a20aff7259c749894fde72952",
+    "zh:bd36b8892e6d77007e436d373c30fd36aee7afcf13fee19254b2491471f65e73",
+    "zh:d0b3e6d3bae5a68dda5607b04413027d612fd117f4dd7762f69b5db101524ca1",
+    "zh:eba24876922d1db24c51c619588299f50e2a661ac6fe4852cf037a44cff81d7b",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Requirements:
 
 - [Python 3](https://python.org)
 - [Pipenv](https://pipenv.pypa.io/)
-- [Terraform](https://www.terraform.io/) version 0.11.14
+- [Terraform](https://www.terraform.io/) version 1.2.5
 
 The following commands will run the lints:
 
@@ -153,7 +153,7 @@ Requirements:
 
 - [Docker](https://www.docker.com/)
 - [GNU Make](https://www.gnu.org/software/make/)
-- [Terraform](https://www.terraform.io/) version 0.11.14
+- [Terraform](https://www.terraform.io/) version 1.2.5
 - [Python 3](https://python.org)
 - access credentials to the Google Cloud Platform project, saved to a file named
   `google-cloud-platform-credentials.json` in the root pf this repository

--- a/infrastructure/docker-image/main.tf
+++ b/infrastructure/docker-image/main.tf
@@ -1,11 +1,11 @@
 variable "registry" {
   description = "Host name of the Docker registry from which the image identifier should be retirieved"
-  type        = "string"
+  type        = string
 }
 
 variable "image" {
   description = "Name of the Docker image whose identifier should be retrieved"
-  type        = "string"
+  type        = string
 }
 
 output "identifier" {
@@ -17,8 +17,8 @@ data "external" "image" {
     "python3",
     "${path.module}/latest-image.py",
     "--registry",
-    "${var.registry}",
+    var.registry,
     "--image",
-    "${var.image}",
+    var.image,
   ]
 }

--- a/infrastructure/docker-image/versions.tf
+++ b/infrastructure/docker-image/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = "~> 1.2.5"
+  required_providers {
+    external = {
+      source = "hashicorp/external"
+    }
+  }
+}

--- a/infrastructure/web-platform-tests/compute.tf
+++ b/infrastructure/web-platform-tests/compute.tf
@@ -1,0 +1,291 @@
+# Contains the configurations for the Compute Engine section of Google Cloud
+# These configurations come from modules that are now archived:
+# - Cert Renewer used: github.com/dcaba/terraform-google-managed-instance-group
+# - WPT Server used: github.com/ecosystem-infra/terraform-google-multi-port-managed-instance-group
+# Most hardcoded defaults come from those aforementioned modules.
+
+########################################
+# WPT Server
+# These configurations come from: github.com/ecosystem-infra/terraform-google-multi-port-managed-instance-group
+# More information about how it was used previously: https://github.com/web-platform-tests/wpt.live/blob/67dc5976ccce2e64483f2028a35659d4d6e58891/infrastructure/web-platform-tests/main.tf#L69-L137
+########################################
+
+resource "google_compute_health_check" "wpt_health_check" {
+  name = "${var.name}-wpt-servers"
+
+  check_interval_sec  = 10
+  timeout_sec         = 10
+  healthy_threshold   = 3
+  unhealthy_threshold = 6
+
+  https_health_check {
+    port = "443"
+    # A query parameter is used to distinguish the health check in the server's
+    # request logs.
+    request_path = "/?gcp-health-check"
+  }
+}
+
+resource "google_compute_instance_group_manager" "wpt_servers" {
+  name               = "${var.name}-wpt-servers"
+  zone               = var.zone
+  description        = "compute VM Instance Group"
+  wait_for_instances = false
+  base_instance_name = "${var.name}-wpt-servers"
+  version {
+    name              = "${var.name}-wpt-servers-default"
+    instance_template = google_compute_instance_template.wpt_server.self_link
+  }
+  update_policy {
+    type                  = local.update_policy.type
+    minimal_action        = local.update_policy.minimal_action
+    max_unavailable_fixed = local.update_policy.max_unavailable_fixed
+  }
+  target_pools = [google_compute_target_pool.default.self_link]
+  target_size  = 2
+
+  dynamic "named_port" {
+    for_each = var.wpt_server_ports
+    content {
+      name = named_port.value["name"]
+      port = named_port.value["port"]
+    }
+  }
+
+  auto_healing_policies {
+    health_check      = google_compute_health_check.wpt_health_check.self_link
+    initial_delay_sec = 30
+  }
+}
+
+resource "google_compute_firewall" "wpt-server-mig-health-check" {
+  name    = "${var.name}-wpt-servers-vm-hc"
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    # https port
+    ports = [var.wpt_server_ports[2].port]
+  }
+
+  # This range comes from this module that was used previously:
+  # https://github.com/Ecosystem-Infra/terraform-google-multi-port-managed-instance-group/blob/master/main.tf#L347
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["${var.name}-allow"]
+}
+
+resource "google_compute_firewall" "wpt-servers-default-ssh" {
+  name    = "${var.name}-wpt-servers-vm-ssh"
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-ssh"]
+}
+
+resource "google_compute_instance_template" "wpt_server" {
+  name_prefix = "default-"
+
+  tags = ["allow-ssh", "${var.name}-allow"]
+
+  # As of 2020-06-17, we were running into OOM issues with the 1.7 GB
+  # "g1-small" instance[1]. This was suspected to be due to 'git gc' needing
+  # more memory, so we upgraded to "e2-medium" (4 GB of RAM).
+  #
+  # [1] https://github.com/web-platform-tests/wpt.live/issues/30
+  machine_type = "e2-medium"
+
+  # The "google-logging-enabled" metadata is undocumented, but it is apparently
+  # necessary to enable the capture of logs from the Docker image.
+  #
+  # https://github.com/GoogleCloudPlatform/konlet/issues/56
+  labels = {
+    "${module.wpt-server-container.vm_container_label_key}" = module.wpt-server-container.vm_container_label
+  }
+
+  network_interface {
+    network    = var.network_name
+    subnetwork = var.subnetwork_name
+    access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+
+  can_ip_forward = false
+
+  // Create a new boot disk from an image
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = module.wpt-server-container.source_image
+    type         = "PERSISTENT"
+    disk_type    = "pd-ssd"
+    disk_size_gb = var.wpt_server_disk_size
+    mode         = "READ_WRITE"
+  }
+
+  service_account {
+    email  = "default"
+    scopes = ["storage-ro", "logging-write"]
+  }
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  # startup-script and tf_depends_id comes from the module previously used for wpt-server. (see link at top)
+  # TODO: evaluate if those two should be removed.
+  metadata = {
+    # "${module.wpt-server-container.metadata_key}" = module.wpt-server-container.metadata_value
+    # The value for ${module.wpt-server-container.metadata_key} is temporary. During the upgrade, the metadata rendering changes.
+    # More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/master/docs/upgrading_to_v2.0.md
+    # Clarification to the linked docs, metadata changes will destroy the old template and create a new one.
+    # In order to make this as smooth as possible, we will hardcode this.
+    # When ready, remove this temporary metadata and the one on cert-renewer. And uncomment the line above.
+    "${module.wpt-server-container.metadata_key}" = <<-EOT
+              ---
+              spec:
+                containers:
+                - env:
+                  - name: WPT_HOST
+                    value: wpt.live
+                  - name: WPT_ALT_HOST
+                    value: not-wpt.live
+                  - name: WPT_BUCKET
+                    value: wpt-tot-certificates
+                  image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe
+                restartPolicy: Always
+                volumes: []
+              EOT
+    "startup-script"                              = ""
+    "tf_depends_id"                               = ""
+    "google-logging-enabled"                      = "true"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+########################################
+# Cert Renewers
+# These configurations come from: github.com/dcaba/terraform-google-managed-instance-group
+# More information about how it was used previously: https://github.com/web-platform-tests/wpt.live/blob/67dc5976ccce2e64483f2028a35659d4d6e58891/infrastructure/web-platform-tests/main.tf#L139-L178
+########################################
+
+resource "google_compute_instance_template" "cert_renewers" {
+  name_prefix = "default-"
+
+  machine_type = "f1-micro"
+
+  region = var.region
+
+  tags = ["allow-ssh", "${var.name}-allow"]
+
+  labels = {
+    "${module.cert-renewer-container.vm_container_label_key}" = module.cert-renewer-container.vm_container_label
+  }
+
+  network_interface {
+    network    = var.network_name
+    subnetwork = var.subnetwork_name
+    network_ip = ""
+    access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+
+  can_ip_forward = false
+
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = module.cert-renewer-container.source_image
+    type         = "PERSISTENT"
+    disk_type    = "pd-ssd"
+    mode         = "READ_WRITE"
+  }
+
+  service_account {
+    email  = "default"
+    scopes = ["cloud-platform"]
+  }
+
+  # startup-script and tf_depends_id comes from the module previously used for cert renewer. (see link at top)
+  # TODO: evaluate if those two should be removed.
+  metadata = {
+    # "${module.cert-renewer-container.metadata_key}" = module.cert-renewer-container.metadata_value
+    # The value for ${module.cert-renewer-container.metadata_key} is temporary. During the upgrade, the metadata rendering changes.
+    # More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/master/docs/upgrading_to_v2.0.md
+    # Clarification to the linked docs, metadata changes will destroy the old template and create a new one.
+    # In order to make this as smooth as possible, we will hardcode this.
+    # When ready, remove this temporary metadata and the one on wpt-server. And uncomment the line above.
+    "${module.cert-renewer-container.metadata_key}" = <<-EOT
+              ---
+              spec:
+                containers:
+                - env:
+                  - name: WPT_HOST
+                    value: wpt.live
+                  - name: WPT_ALT_HOST
+                    value: not-wpt.live
+                  - name: WPT_BUCKET
+                    value: wpt-tot-certificates
+                  image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5
+                restartPolicy: Always
+                volumes: []
+              EOT
+    "startup-script"                                = ""
+    "tf_depends_id"                                 = ""
+    "google-logging-enabled"                        = "true"
+  }
+
+  scheduling {
+    preemptible         = false
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "cert_renewers" {
+  name               = "${var.name}-cert-renewers"
+  description        = "compute VM Instance Group"
+  wait_for_instances = false
+
+  base_instance_name = "${var.name}-cert-renewers"
+
+  version {
+    instance_template = google_compute_instance_template.cert_renewers.self_link
+  }
+
+  zone = var.zone
+
+  update_policy {
+    # The type is different from wpt servers's update policy.
+    # TODO: Evaluate why
+    type                  = "OPPORTUNISTIC"
+    minimal_action        = local.update_policy.minimal_action
+    max_unavailable_fixed = local.update_policy.max_unavailable_fixed
+  }
+
+  target_pools = []
+
+  target_size = 1
+
+  dynamic "named_port" {
+    for_each = var.cert_renewer_ports
+    content {
+      name = named_port.value["name"]
+      port = named_port.value["port"]
+    }
+  }
+}

--- a/infrastructure/web-platform-tests/load-balancing.tf
+++ b/infrastructure/web-platform-tests/load-balancing.tf
@@ -7,33 +7,25 @@
 locals {
   lb_name = "${var.name}-load-balancing"
 
-  forwarded_ports = [
-    "${module.wpt-servers.service_port_1}",
-    "${module.wpt-servers.service_port_2}",
-    "${module.wpt-servers.service_port_3}",
-    "${module.wpt-servers.service_port_4}",
-    "${module.wpt-servers.service_port_5}",
-    "${module.wpt-servers.service_port_6}",
-    "${module.wpt-servers.service_port_7}",
-  ]
+  forwarded_ports = [for wpt_server_port in var.wpt_server_ports : wpt_server_port.port]
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  count                 = "${length(local.forwarded_ports)}"
+  count                 = length(local.forwarded_ports)
   name                  = "${local.lb_name}-${count.index}"
-  target                = "${google_compute_target_pool.default.self_link}"
+  target                = google_compute_target_pool.default.self_link
   load_balancing_scheme = "EXTERNAL"
-  port_range            = "${local.forwarded_ports[count.index]}"
-  ip_address            = "${google_compute_address.web-platform-tests-live-address.address}"
+  port_range            = local.forwarded_ports[count.index]
+  ip_address            = google_compute_address.web-platform-tests-live-address.address
 }
 
 resource "google_compute_target_pool" "default" {
-  name             = "${local.lb_name}"
-  region           = "${var.region}"
+  name             = local.lb_name
+  region           = var.region
   session_affinity = "CLIENT_IP_PROTO"
 
   health_checks = [
-    "${google_compute_http_health_check.default.name}",
+    google_compute_http_health_check.default.name,
   ]
 }
 
@@ -44,18 +36,18 @@ resource "google_compute_http_health_check" "default" {
   # request logs.
   request_path = "/?gcp-health-check-load-balancing"
 
-  port = "${module.wpt-servers.service_port_1}"
+  port = var.wpt_server_ports[0].port
 }
 
 resource "google_compute_firewall" "default-lb-fw" {
   name    = "${local.lb_name}-vm-service"
-  network = "${var.network_name}"
+  network = var.network_name
 
   allow {
     protocol = "tcp"
-    ports    = "${local.forwarded_ports}"
+    ports    = local.forwarded_ports
   }
 
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["${module.wpt-servers.target_tags}"]
+  target_tags   = ["${var.name}-allow"]
 }

--- a/infrastructure/web-platform-tests/main.tf
+++ b/infrastructure/web-platform-tests/main.tf
@@ -1,39 +1,36 @@
-# https://github.com/hashicorp/terraform/issues/17399
-provider "google-beta" {}
-
 locals {
   bucket_name = "${var.name}-certificates"
 
-  update_policy = [
-    {
-      type           = "PROACTIVE"
-      minimal_action = "RESTART"
+  update_policy = {
+    type           = "PROACTIVE"
+    minimal_action = "RESTART"
+    # > maxUnavailable must be greater than 0 when minimal action is set to
+    # > RESTART
+    max_unavailable_fixed = 1
+  }
 
-      # > maxUnavailable must be greater than 0 when minimal action is set to
-      # > RESTART
-      max_unavailable_fixed = 1
-    },
-  ]
 }
 
 module "wpt-server-container" {
-  source = "github.com/terraform-google-modules/terraform-google-container-vm?ref=v0.3.0"
+  source  = "terraform-google-modules/container-vm/google"
+  version = "3.0.0"
 
+  # Temporary variable
+  cos_image_name = var.cos_image_name
   container = {
-    image = "${var.wpt_server_image}"
-
+    image = var.wpt_server_image
     env = [
       {
         name  = "WPT_HOST"
-        value = "${var.host_name}"
+        value = var.host_name
       },
       {
         name  = "WPT_ALT_HOST"
-        value = "${var.alt_host_name}"
+        value = var.alt_host_name
       },
       {
         name  = "WPT_BUCKET"
-        value = "${local.bucket_name}"
+        value = local.bucket_name
       },
     ]
   }
@@ -42,23 +39,25 @@ module "wpt-server-container" {
 }
 
 module "cert-renewer-container" {
-  source = "github.com/terraform-google-modules/terraform-google-container-vm?ref=v0.3.0"
+  source  = "terraform-google-modules/container-vm/google"
+  version = "3.0.0"
 
+  # Temporary variable
+  cos_image_name = var.cos_image_name
   container = {
-    image = "${var.cert_renewer_image}"
-
+    image = var.cert_renewer_image
     env = [
       {
         name  = "WPT_HOST"
-        value = "${var.host_name}"
+        value = var.host_name
       },
       {
         name  = "WPT_ALT_HOST"
-        value = "${var.alt_host_name}"
+        value = var.alt_host_name
       },
       {
         name  = "WPT_BUCKET"
-        value = "${local.bucket_name}"
+        value = local.bucket_name
       },
     ]
   }
@@ -66,117 +65,7 @@ module "cert-renewer-container" {
   restart_policy = "Always"
 }
 
-module "wpt-servers" {
-  source = "github.com/ecosystem-infra/terraform-google-multi-port-managed-instance-group?ref=a40a3b9f3"
-
-  providers {
-    google-beta = "google-beta"
-  }
-
-  region        = "${var.region}"
-  zone          = "${var.zone}"
-  name          = "${var.name}-wpt-servers"
-  size          = 2
-  compute_image = "${module.wpt-server-container.source_image}"
-
-  # As of 2020-06-17, we were running into OOM issues with the 1.7 GB
-  # "g1-small" instance[1]. This was suspected to be due to 'git gc' needing
-  # more memory, so we upgraded to "e2-medium" (4 GB of RAM).
-  #
-  # [1] https://github.com/web-platform-tests/wpt.live/issues/30
-  machine_type = "e2-medium"
-
-  instance_labels = "${map(
-    module.wpt-server-container.vm_container_label_key,
-    module.wpt-server-container.vm_container_label
-  )}"
-
-  # The "google-logging-enabled" metadata is undocumented, but it is apparently
-  # necessary to enable the capture of logs from the Docker image.
-  #
-  # https://github.com/GoogleCloudPlatform/konlet/issues/56
-  metadata = "${map(
-    module.wpt-server-container.metadata_key,
-    module.wpt-server-container.metadata_value,
-    "google-logging-enabled",
-    "true"
-  )}"
-
-  service_port_1      = 80
-  service_port_1_name = "http-primary"
-  service_port_2      = 8000
-  service_port_2_name = "http-secondary"
-  service_port_3      = 443
-  service_port_3_name = "https"
-  service_port_4      = 8001
-  service_port_4_name = "http2"
-  service_port_5      = 8002
-  service_port_5_name = "websocket"
-  service_port_6      = 8003
-  service_port_6_name = "websocket-secure"
-  service_port_7      = 8443
-  service_port_7_name = "https-secondary"
-  ssh_fw_rule         = true
-  https_health_check  = true
-
-  # A query parameter is used to distinguish the health check in the server's
-  # request logs.
-  hc_path = "/?gcp-health-check"
-
-  hc_port                = 443
-  hc_interval            = 10
-  hc_healthy_threshold   = 3
-  hc_unhealthy_threshold = 6
-  target_pools           = ["${google_compute_target_pool.default.self_link}"]
-  target_tags            = ["${var.name}-allow"]
-  network                = "${var.network_name}"
-  subnetwork             = "${var.subnetwork_name}"
-  service_account_scopes = ["storage-ro", "logging-write"]
-  update_policy          = "${local.update_policy}"
-  disk_size_gb           = "${var.wpt_server_disk_size}"
-}
-
-module "cert-renewers" {
-  # https://github.com/GoogleCloudPlatform/terraform-google-managed-instance-group/pull/39
-  source = "github.com/dcaba/terraform-google-managed-instance-group?ref=340409c"
-
-  providers {
-    google-beta = "google-beta"
-  }
-
-  region        = "${var.region}"
-  zone          = "${var.zone}"
-  name          = "${var.name}-cert-renewers"
-  size          = 1
-  compute_image = "${module.cert-renewer-container.source_image}"
-
-  instance_labels = "${map(
-    module.cert-renewer-container.vm_container_label_key,
-    module.cert-renewer-container.vm_container_label
-  )}"
-
-  # The "google-logging-enabled" metadata is undocumented, but it is apparently
-  # necessary to enable the capture of logs from the Docker image.
-  #
-  # https://github.com/GoogleCloudPlatform/konlet/issues/56
-  metadata = "${map(
-    module.cert-renewer-container.metadata_key,
-    module.cert-renewer-container.metadata_value,
-    "google-logging-enabled",
-    "true"
-  )}"
-
-  service_port           = 8004
-  service_port_name      = "http"
-  ssh_fw_rule            = false
-  http_health_check      = false
-  target_tags            = ["${var.name}-allow"]
-  network                = "${var.network_name}"
-  subnetwork             = "${var.subnetwork_name}"
-  service_account_scopes = ["cloud-platform"]
-  update_policy          = "${local.update_policy}"
-}
-
 resource "google_storage_bucket" "certificates" {
-  name = "${local.bucket_name}"
+  name     = local.bucket_name
+  location = "US"
 }

--- a/infrastructure/web-platform-tests/networking.tf
+++ b/infrastructure/web-platform-tests/networking.tf
@@ -3,17 +3,17 @@ resource "google_compute_address" "web-platform-tests-live-address" {
 }
 
 data "google_dns_managed_zone" "host" {
-  name = "${var.host_zone_name}"
+  name = var.host_zone_name
 }
 
 resource "google_dns_record_set" "host_bare" {
-  name = "${data.google_dns_managed_zone.host.dns_name}"
+  name = data.google_dns_managed_zone.host.dns_name
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.host.name}"
+  managed_zone = data.google_dns_managed_zone.host.name
 
-  rrdatas = ["${google_compute_address.web-platform-tests-live-address.address}"]
+  rrdatas = [google_compute_address.web-platform-tests-live-address.address]
 }
 
 resource "google_dns_record_set" "host_subdomains" {
@@ -21,9 +21,9 @@ resource "google_dns_record_set" "host_subdomains" {
   type = "CNAME"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.host.name}"
+  managed_zone = data.google_dns_managed_zone.host.name
 
-  rrdatas = ["${data.google_dns_managed_zone.host.dns_name}"]
+  rrdatas = [data.google_dns_managed_zone.host.dns_name]
 }
 
 resource "google_dns_record_set" "host_nonexistent_subdomains" {
@@ -31,23 +31,23 @@ resource "google_dns_record_set" "host_nonexistent_subdomains" {
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.host.name}"
+  managed_zone = data.google_dns_managed_zone.host.name
 
   rrdatas = ["0.0.0.0"]
 }
 
 data "google_dns_managed_zone" "alt_host" {
-  name = "${var.alt_host_zone_name}"
+  name = var.alt_host_zone_name
 }
 
 resource "google_dns_record_set" "alt_host_bare" {
-  name = "${data.google_dns_managed_zone.alt_host.dns_name}"
+  name = data.google_dns_managed_zone.alt_host.dns_name
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.alt_host.name}"
+  managed_zone = data.google_dns_managed_zone.alt_host.name
 
-  rrdatas = ["${google_compute_address.web-platform-tests-live-address.address}"]
+  rrdatas = [google_compute_address.web-platform-tests-live-address.address]
 }
 
 resource "google_dns_record_set" "alt_host_subdomains" {
@@ -55,9 +55,9 @@ resource "google_dns_record_set" "alt_host_subdomains" {
   type = "CNAME"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.alt_host.name}"
+  managed_zone = data.google_dns_managed_zone.alt_host.name
 
-  rrdatas = ["${data.google_dns_managed_zone.alt_host.dns_name}"]
+  rrdatas = [data.google_dns_managed_zone.alt_host.dns_name]
 }
 
 resource "google_dns_record_set" "alt_host_nonexistent_subdomains" {
@@ -65,7 +65,7 @@ resource "google_dns_record_set" "alt_host_nonexistent_subdomains" {
   type = "A"
   ttl  = 300
 
-  managed_zone = "${data.google_dns_managed_zone.alt_host.name}"
+  managed_zone = data.google_dns_managed_zone.alt_host.name
 
   rrdatas = ["0.0.0.0"]
 }

--- a/infrastructure/web-platform-tests/outputs.tf
+++ b/infrastructure/web-platform-tests/outputs.tf
@@ -1,3 +1,3 @@
 output "address" {
-  value = "${google_compute_address.web-platform-tests-live-address.address}"
+  value = google_compute_address.web-platform-tests-live-address.address
 }

--- a/infrastructure/web-platform-tests/variables.tf
+++ b/infrastructure/web-platform-tests/variables.tf
@@ -1,52 +1,111 @@
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "zone" {
-  type = "string"
+  type = string
 }
 
 variable "name" {
-  type = "string"
+  type = string
 }
 
 variable "network_name" {
-  type = "string"
+  type = string
 }
 
 variable "subnetwork_name" {
-  type = "string"
+  type = string
 }
 
 variable "host_zone_name" {
-  type        = "string"
+  type        = string
   description = "The primary host to be used by the web-platform-tests server"
 }
 
 variable "host_name" {
-  type = "string"
+  type = string
 }
 
 variable "alt_host_zone_name" {
-  type        = "string"
+  type        = string
   description = "The secondary host to be used by the web-platform-tests server"
 }
 
 variable "alt_host_name" {
-  type = "string"
+  type = string
 }
 
 variable "wpt_server_image" {
-  type        = "string"
+  type        = string
   description = "The address of a Docker image that runs the web-platform-tests server"
 }
 
 variable "cert_renewer_image" {
-  type        = "string"
+  type        = string
   description = "The address of of a Docker image that renews TLS certificates for the system"
 }
 
 variable "wpt_server_disk_size" {
   description = "The size of the disk in gigabytes. If not specified, it will inherit the size of its base image."
   default     = 0
+}
+
+variable "wpt_server_ports" {
+  type = list(object({
+    name = string
+    port = number
+  }))
+  description = "Mapping of name to port. Ports are used for the wpt server."
+  default = [
+    {
+      name = "http-primary",
+      port = 80
+    },
+    {
+      name = "http-secondary",
+      port = 8000
+    },
+    {
+      name = "https",
+      port = 443
+    },
+    {
+      name = "http2",
+      port = 8001
+    },
+    {
+      name = "websocket",
+      port = 8002
+    },
+    {
+      name = "websocket-secure",
+      port = 8003
+    },
+    {
+      name = "https-secondary",
+      port = 8443
+    },
+  ]
+}
+
+
+variable "cert_renewer_ports" {
+  type = list(object({
+    name = string
+    port = number
+  }))
+  description = "Mapping of name to port. Ports are used for the cert renewer."
+  default = [
+    {
+      name = "http",
+      port = 8004
+    }
+  ]
+}
+
+variable "cos_image_name" {
+  description = "Name of specific COS image. Temporary variable. Will remove here and in main.tf once ready to upgrade. More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/5e69eafaaaa8302c5732799e32d1da5c17b7b285/variables.tf#L46"
+  type        = string
+  default     = "cos-stable-85-13310-1209-17"
 }

--- a/infrastructure/web-platform-tests/versions.tf
+++ b/infrastructure/web-platform-tests/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = "~> 1.2.5"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -5,15 +5,9 @@ locals {
 }
 
 provider "google" {
-  project     = "${local.project_name}"
-  region      = "${local.region}"
-  credentials = "${file("google-cloud-platform-credentials.json")}"
-}
-
-provider "google-beta" {
-  project     = "${local.project_name}"
-  region      = "${local.region}"
-  credentials = "${file("google-cloud-platform-credentials.json")}"
+  project     = local.project_name
+  region      = local.region
+  credentials = file("google-cloud-platform-credentials.json")
 }
 
 resource "google_compute_network" "default" {
@@ -24,8 +18,8 @@ resource "google_compute_network" "default" {
 resource "google_compute_subnetwork" "default" {
   name                     = "wpt-live-subnetwork"
   ip_cidr_range            = "10.127.0.0/20"
-  network                  = "${google_compute_network.default.self_link}"
-  region                   = "${local.region}"
+  network                  = google_compute_network.default.self_link
+  region                   = local.region
   private_ip_google_access = true
 }
 
@@ -44,24 +38,21 @@ module "cert-renewer-image" {
 module "wpt-live" {
   source = "./infrastructure/web-platform-tests"
 
-  providers {
-    google-beta = "google-beta"
-  }
-
   name               = "wpt-tot"
-  network_name       = "${google_compute_network.default.name}"
-  subnetwork_name    = "${google_compute_subnetwork.default.name}"
+  network_name       = google_compute_network.default.name
+  subnetwork_name    = google_compute_subnetwork.default.name
   host_zone_name     = "wpt-live"
   host_name          = "wpt.live"
   alt_host_zone_name = "not-wpt-live"
   alt_host_name      = "not-wpt.live"
-  region             = "${local.region}"
-  zone               = "${local.zone}"
+  region             = local.region
+  zone               = local.zone
 
-  wpt_server_image   = "${module.wpt-server-tot-image.identifier}"
-  cert_renewer_image = "${module.cert-renewer-image.identifier}"
+  wpt_server_image   = module.wpt-server-tot-image.identifier
+  cert_renewer_image = module.cert-renewer-image.identifier
 }
 
 output "wpt-live-address" {
-  value = "${module.wpt-live.address}"
+  value = module.wpt-live.address
 }
+

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,1857 +1,1609 @@
 {
-    "version": 3,
-    "terraform_version": "0.11.14",
-    "serial": 18,
-    "lineage": "3e752c40-46ae-cf3a-9a1d-073d2251df8c",
-    "modules": [
+  "version": 4,
+  "terraform_version": "1.2.5",
+  "serial": 25,
+  "lineage": "3e752c40-46ae-cf3a-9a1d-073d2251df8c",
+  "outputs": {
+    "wpt-live-address": {
+      "value": "35.223.122.27",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "google_compute_network",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
         {
-            "path": [
-                "root"
-            ],
-            "outputs": {
-                "wpt-live-address": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "35.223.122.27"
-                }
-            },
-            "resources": {
-                "google_compute_network.default": {
-                    "type": "google_compute_network",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "wpt-live-network",
-                        "attributes": {
-                            "auto_create_subnetworks": "false",
-                            "delete_default_routes_on_create": "false",
-                            "description": "",
-                            "gateway_ipv4": "",
-                            "id": "wpt-live-network",
-                            "ipv4_range": "",
-                            "name": "wpt-live-network",
-                            "project": "wpt-live",
-                            "routing_mode": "REGIONAL",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_subnetwork.default": {
-                    "type": "google_compute_subnetwork",
-                    "depends_on": [
-                        "google_compute_network.default",
-                        "local.region"
-                    ],
-                    "primary": {
-                        "id": "us-central1/wpt-live-subnetwork",
-                        "attributes": {
-                            "creation_timestamp": "2019-10-30T15:49:56.487-07:00",
-                            "description": "",
-                            "enable_flow_logs": "false",
-                            "fingerprint": "_4CEx9NGrfE=",
-                            "gateway_address": "10.127.0.1",
-                            "id": "us-central1/wpt-live-subnetwork",
-                            "ip_cidr_range": "10.127.0.0/20",
-                            "log_config.#": "0",
-                            "name": "wpt-live-subnetwork",
-                            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "private_ip_google_access": "true",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "secondary_ip_range.#": "0",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 360000000000,
-                                "delete": 360000000000,
-                                "update": 360000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                }
-            },
-            "depends_on": []
-        },
-        {
-            "path": [
-                "root",
-                "cert-renewer-image"
-            ],
-            "outputs": {
-                "identifier": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5"
-                }
-            },
-            "resources": {
-                "data.external.image": {
-                    "type": "external",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "-",
-                        "attributes": {
-                            "id": "-",
-                            "program.#": "6",
-                            "program.0": "python3",
-                            "program.1": "/usr/local/google/home/smcgruer/github/wpt.live/.terraform/modules/a78ed6de1faf685715b06f31ed53b9e6/latest-image.py",
-                            "program.2": "--registry",
-                            "program.3": "gcr.io",
-                            "program.4": "--image",
-                            "program.5": "wpt-live/wpt-live-cert-renewer",
-                            "result.%": "2",
-                            "result.identifier": "sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5",
-                            "result.time_created": "1570479055243"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.external"
-                }
-            },
-            "depends_on": []
-        },
-        {
-            "path": [
-                "root",
-                "wpt-live"
-            ],
-            "outputs": {
-                "address": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "35.223.122.27"
-                }
-            },
-            "resources": {
-                "data.google_dns_managed_zone.alt_host": {
-                    "type": "google_dns_managed_zone",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "not-wpt-live",
-                        "attributes": {
-                            "description": "",
-                            "dns_name": "not-wpt.live.",
-                            "id": "not-wpt-live",
-                            "name": "not-wpt-live",
-                            "name_servers.#": "4",
-                            "name_servers.1308706956": "ns-cloud-a1.googledomains.com.",
-                            "name_servers.2865056241": "ns-cloud-a3.googledomains.com.",
-                            "name_servers.3273838505": "ns-cloud-a4.googledomains.com.",
-                            "name_servers.891275887": "ns-cloud-a2.googledomains.com."
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "data.google_dns_managed_zone.host": {
-                    "type": "google_dns_managed_zone",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "wpt-live",
-                        "attributes": {
-                            "description": "",
-                            "dns_name": "wpt.live.",
-                            "id": "wpt-live",
-                            "name": "wpt-live",
-                            "name_servers.#": "4",
-                            "name_servers.2004477388": "ns-cloud-b1.googledomains.com.",
-                            "name_servers.208103215": "ns-cloud-b2.googledomains.com.",
-                            "name_servers.2478695601": "ns-cloud-b3.googledomains.com.",
-                            "name_servers.4200227561": "ns-cloud-b4.googledomains.com."
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_address.web-platform-tests-live-address": {
-                    "type": "google_compute_address",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "wpt-live/us-central1/wpt-tot-address",
-                        "attributes": {
-                            "address": "35.223.122.27",
-                            "address_type": "EXTERNAL",
-                            "creation_timestamp": "2019-10-30T15:49:38.932-07:00",
-                            "description": "",
-                            "id": "wpt-live/us-central1/wpt-tot-address",
-                            "name": "wpt-tot-address",
-                            "network_tier": "PREMIUM",
-                            "project": "wpt-live",
-                            "purpose": "",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/addresses/wpt-tot-address",
-                            "subnetwork": "",
-                            "users.#": "7",
-                            "users.0": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-0",
-                            "users.1": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-3",
-                            "users.2": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-5",
-                            "users.3": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-2",
-                            "users.4": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-4",
-                            "users.5": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-1",
-                            "users.6": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-6"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_firewall.default-lb-fw": {
-                    "type": "google_compute_firewall",
-                    "depends_on": [
-                        "local.forwarded_ports",
-                        "local.lb_name",
-                        "module.wpt-servers"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-vm-service",
-                        "attributes": {
-                            "allow.#": "1",
-                            "allow.4259431159.ports.#": "7",
-                            "allow.4259431159.ports.0": "80",
-                            "allow.4259431159.ports.1": "8000",
-                            "allow.4259431159.ports.2": "443",
-                            "allow.4259431159.ports.3": "8001",
-                            "allow.4259431159.ports.4": "8002",
-                            "allow.4259431159.ports.5": "8003",
-                            "allow.4259431159.ports.6": "8443",
-                            "allow.4259431159.protocol": "tcp",
-                            "creation_timestamp": "2019-10-30T15:49:56.982-07:00",
-                            "deny.#": "0",
-                            "description": "",
-                            "destination_ranges.#": "0",
-                            "direction": "INGRESS",
-                            "disabled": "false",
-                            "id": "wpt-tot-load-balancing-vm-service",
-                            "name": "wpt-tot-load-balancing-vm-service",
-                            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "priority": "1000",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/firewalls/wpt-tot-load-balancing-vm-service",
-                            "source_ranges.#": "1",
-                            "source_ranges.1080289494": "0.0.0.0/0",
-                            "source_service_accounts.#": "0",
-                            "source_tags.#": "0",
-                            "target_service_accounts.#": "0",
-                            "target_tags.#": "1",
-                            "target_tags.2803589456": "wpt-tot-allow"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            },
-                            "schema_version": "1"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_forwarding_rule.default.0": {
-                    "type": "google_compute_forwarding_rule",
-                    "depends_on": [
-                        "google_compute_address.web-platform-tests-live-address",
-                        "google_compute_target_pool.default",
-                        "local.forwarded_ports",
-                        "local.lb_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-0",
-                        "attributes": {
-                            "all_ports": "false",
-                            "backend_service": "",
-                            "creation_timestamp": "2019-10-30T15:49:46.570-07:00",
-                            "description": "",
-                            "id": "wpt-tot-load-balancing-0",
-                            "ip_address": "35.223.122.27",
-                            "ip_protocol": "TCP",
-                            "ip_version": "",
-                            "load_balancing_scheme": "EXTERNAL",
-                            "name": "wpt-tot-load-balancing-0",
-                            "network": "",
-                            "network_tier": "PREMIUM",
-                            "port_range": "80-80",
-                            "ports.#": "0",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-0",
-                            "service_label": "",
-                            "service_name": "",
-                            "subnetwork": "",
-                            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_forwarding_rule.default.1": {
-                    "type": "google_compute_forwarding_rule",
-                    "depends_on": [
-                        "google_compute_address.web-platform-tests-live-address",
-                        "google_compute_target_pool.default",
-                        "local.forwarded_ports",
-                        "local.lb_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-1",
-                        "attributes": {
-                            "all_ports": "false",
-                            "backend_service": "",
-                            "creation_timestamp": "2019-10-30T15:49:50.318-07:00",
-                            "description": "",
-                            "id": "wpt-tot-load-balancing-1",
-                            "ip_address": "35.223.122.27",
-                            "ip_protocol": "TCP",
-                            "ip_version": "",
-                            "load_balancing_scheme": "EXTERNAL",
-                            "name": "wpt-tot-load-balancing-1",
-                            "network": "",
-                            "network_tier": "PREMIUM",
-                            "port_range": "8000-8000",
-                            "ports.#": "0",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-1",
-                            "service_label": "",
-                            "service_name": "",
-                            "subnetwork": "",
-                            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_forwarding_rule.default.2": {
-                    "type": "google_compute_forwarding_rule",
-                    "depends_on": [
-                        "google_compute_address.web-platform-tests-live-address",
-                        "google_compute_target_pool.default",
-                        "local.forwarded_ports",
-                        "local.lb_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-2",
-                        "attributes": {
-                            "all_ports": "false",
-                            "backend_service": "",
-                            "creation_timestamp": "2019-10-30T15:49:48.236-07:00",
-                            "description": "",
-                            "id": "wpt-tot-load-balancing-2",
-                            "ip_address": "35.223.122.27",
-                            "ip_protocol": "TCP",
-                            "ip_version": "",
-                            "load_balancing_scheme": "EXTERNAL",
-                            "name": "wpt-tot-load-balancing-2",
-                            "network": "",
-                            "network_tier": "PREMIUM",
-                            "port_range": "443-443",
-                            "ports.#": "0",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-2",
-                            "service_label": "",
-                            "service_name": "",
-                            "subnetwork": "",
-                            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_forwarding_rule.default.3": {
-                    "type": "google_compute_forwarding_rule",
-                    "depends_on": [
-                        "google_compute_address.web-platform-tests-live-address",
-                        "google_compute_target_pool.default",
-                        "local.forwarded_ports",
-                        "local.lb_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-3",
-                        "attributes": {
-                            "all_ports": "false",
-                            "backend_service": "",
-                            "creation_timestamp": "2019-10-30T15:49:47.101-07:00",
-                            "description": "",
-                            "id": "wpt-tot-load-balancing-3",
-                            "ip_address": "35.223.122.27",
-                            "ip_protocol": "TCP",
-                            "ip_version": "",
-                            "load_balancing_scheme": "EXTERNAL",
-                            "name": "wpt-tot-load-balancing-3",
-                            "network": "",
-                            "network_tier": "PREMIUM",
-                            "port_range": "8001-8001",
-                            "ports.#": "0",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-3",
-                            "service_label": "",
-                            "service_name": "",
-                            "subnetwork": "",
-                            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_forwarding_rule.default.4": {
-                    "type": "google_compute_forwarding_rule",
-                    "depends_on": [
-                        "google_compute_address.web-platform-tests-live-address",
-                        "google_compute_target_pool.default",
-                        "local.forwarded_ports",
-                        "local.lb_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-4",
-                        "attributes": {
-                            "all_ports": "false",
-                            "backend_service": "",
-                            "creation_timestamp": "2019-10-30T15:49:49.208-07:00",
-                            "description": "",
-                            "id": "wpt-tot-load-balancing-4",
-                            "ip_address": "35.223.122.27",
-                            "ip_protocol": "TCP",
-                            "ip_version": "",
-                            "load_balancing_scheme": "EXTERNAL",
-                            "name": "wpt-tot-load-balancing-4",
-                            "network": "",
-                            "network_tier": "PREMIUM",
-                            "port_range": "8002-8002",
-                            "ports.#": "0",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-4",
-                            "service_label": "",
-                            "service_name": "",
-                            "subnetwork": "",
-                            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_forwarding_rule.default.5": {
-                    "type": "google_compute_forwarding_rule",
-                    "depends_on": [
-                        "google_compute_address.web-platform-tests-live-address",
-                        "google_compute_target_pool.default",
-                        "local.forwarded_ports",
-                        "local.lb_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-5",
-                        "attributes": {
-                            "all_ports": "false",
-                            "backend_service": "",
-                            "creation_timestamp": "2019-10-30T15:49:47.752-07:00",
-                            "description": "",
-                            "id": "wpt-tot-load-balancing-5",
-                            "ip_address": "35.223.122.27",
-                            "ip_protocol": "TCP",
-                            "ip_version": "",
-                            "load_balancing_scheme": "EXTERNAL",
-                            "name": "wpt-tot-load-balancing-5",
-                            "network": "",
-                            "network_tier": "PREMIUM",
-                            "port_range": "8003-8003",
-                            "ports.#": "0",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-5",
-                            "service_label": "",
-                            "service_name": "",
-                            "subnetwork": "",
-                            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_http_health_check.default": {
-                    "type": "google_compute_http_health_check",
-                    "depends_on": [
-                        "local.lb_name",
-                        "module.wpt-servers"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing-health-check",
-                        "attributes": {
-                            "check_interval_sec": "5",
-                            "creation_timestamp": "2019-10-30T15:49:38.750-07:00",
-                            "description": "",
-                            "healthy_threshold": "2",
-                            "host": "",
-                            "id": "wpt-tot-load-balancing-health-check",
-                            "name": "wpt-tot-load-balancing-health-check",
-                            "port": "80",
-                            "project": "wpt-live",
-                            "request_path": "/?gcp-health-check-load-balancing",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/httpHealthChecks/wpt-tot-load-balancing-health-check",
-                            "timeout_sec": "5",
-                            "unhealthy_threshold": "2"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_target_pool.default": {
-                    "type": "google_compute_target_pool",
-                    "depends_on": [
-                        "google_compute_http_health_check.default",
-                        "local.lb_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-load-balancing",
-                        "attributes": {
-                            "backup_pool": "",
-                            "description": "",
-                            "failover_ratio": "0",
-                            "health_checks.#": "1",
-                            "health_checks.0": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/httpHealthChecks/wpt-tot-load-balancing-health-check",
-                            "id": "wpt-tot-load-balancing",
-                            "instances.#": "2",
-                            "instances.1020124084": "us-central1-b/wpt-tot-wpt-servers-56g3",
-                            "instances.2918530077": "us-central1-b/wpt-tot-wpt-servers-kgdh",
-                            "name": "wpt-tot-load-balancing",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
-                            "session_affinity": "CLIENT_IP_PROTO"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_dns_record_set.alt_host_bare": {
-                    "type": "google_dns_record_set",
-                    "depends_on": [
-                        "data.google_dns_managed_zone.alt_host",
-                        "google_compute_address.web-platform-tests-live-address"
-                    ],
-                    "primary": {
-                        "id": "not-wpt-live/not-wpt.live./A",
-                        "attributes": {
-                            "id": "not-wpt-live/not-wpt.live./A",
-                            "managed_zone": "not-wpt-live",
-                            "name": "not-wpt.live.",
-                            "project": "wpt-live",
-                            "rrdatas.#": "1",
-                            "rrdatas.0": "35.223.122.27",
-                            "ttl": "300",
-                            "type": "A"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_dns_record_set.alt_host_nonexistent_subdomains": {
-                    "type": "google_dns_record_set",
-                    "depends_on": [
-                        "data.google_dns_managed_zone.alt_host"
-                    ],
-                    "primary": {
-                        "id": "not-wpt-live/nonexistent.not-wpt.live./A",
-                        "attributes": {
-                            "id": "not-wpt-live/nonexistent.not-wpt.live./A",
-                            "managed_zone": "not-wpt-live",
-                            "name": "nonexistent.not-wpt.live.",
-                            "project": "wpt-live",
-                            "rrdatas.#": "1",
-                            "rrdatas.0": "0.0.0.0",
-                            "ttl": "300",
-                            "type": "A"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_dns_record_set.alt_host_subdomains": {
-                    "type": "google_dns_record_set",
-                    "depends_on": [
-                        "data.google_dns_managed_zone.alt_host"
-                    ],
-                    "primary": {
-                        "id": "not-wpt-live/*.not-wpt.live./CNAME",
-                        "attributes": {
-                            "id": "not-wpt-live/*.not-wpt.live./CNAME",
-                            "managed_zone": "not-wpt-live",
-                            "name": "*.not-wpt.live.",
-                            "project": "wpt-live",
-                            "rrdatas.#": "1",
-                            "rrdatas.0": "not-wpt.live.",
-                            "ttl": "300",
-                            "type": "CNAME"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_dns_record_set.host_bare": {
-                    "type": "google_dns_record_set",
-                    "depends_on": [
-                        "data.google_dns_managed_zone.host",
-                        "google_compute_address.web-platform-tests-live-address"
-                    ],
-                    "primary": {
-                        "id": "wpt-live/wpt.live./A",
-                        "attributes": {
-                            "id": "wpt-live/wpt.live./A",
-                            "managed_zone": "wpt-live",
-                            "name": "wpt.live.",
-                            "project": "wpt-live",
-                            "rrdatas.#": "1",
-                            "rrdatas.0": "35.223.122.27",
-                            "ttl": "300",
-                            "type": "A"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_dns_record_set.host_nonexistent_subdomains": {
-                    "type": "google_dns_record_set",
-                    "depends_on": [
-                        "data.google_dns_managed_zone.host"
-                    ],
-                    "primary": {
-                        "id": "wpt-live/nonexistent.wpt.live./A",
-                        "attributes": {
-                            "id": "wpt-live/nonexistent.wpt.live./A",
-                            "managed_zone": "wpt-live",
-                            "name": "nonexistent.wpt.live.",
-                            "project": "wpt-live",
-                            "rrdatas.#": "1",
-                            "rrdatas.0": "0.0.0.0",
-                            "ttl": "300",
-                            "type": "A"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_dns_record_set.host_subdomains": {
-                    "type": "google_dns_record_set",
-                    "depends_on": [
-                        "data.google_dns_managed_zone.host"
-                    ],
-                    "primary": {
-                        "id": "wpt-live/*.wpt.live./CNAME",
-                        "attributes": {
-                            "id": "wpt-live/*.wpt.live./CNAME",
-                            "managed_zone": "wpt-live",
-                            "name": "*.wpt.live.",
-                            "project": "wpt-live",
-                            "rrdatas.#": "1",
-                            "rrdatas.0": "wpt.live.",
-                            "ttl": "300",
-                            "type": "CNAME"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_storage_bucket.certificates": {
-                    "type": "google_storage_bucket",
-                    "depends_on": [
-                        "local.bucket_name"
-                    ],
-                    "primary": {
-                        "id": "wpt-tot-certificates",
-                        "attributes": {
-                            "bucket_policy_only": "false",
-                            "cors.#": "0",
-                            "encryption.#": "0",
-                            "force_destroy": "false",
-                            "id": "wpt-tot-certificates",
-                            "labels.%": "0",
-                            "lifecycle_rule.#": "0",
-                            "location": "US",
-                            "logging.#": "0",
-                            "name": "wpt-tot-certificates",
-                            "project": "wpt-live",
-                            "requester_pays": "false",
-                            "retention_policy.#": "0",
-                            "self_link": "https://www.googleapis.com/storage/v1/b/wpt-tot-certificates",
-                            "storage_class": "STANDARD",
-                            "url": "gs://wpt-tot-certificates",
-                            "versioning.#": "0",
-                            "website.#": "0"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                }
-            },
-            "depends_on": []
-        },
-        {
-            "path": [
-                "root",
-                "wpt-server-tot-image"
-            ],
-            "outputs": {
-                "identifier": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe"
-                }
-            },
-            "resources": {
-                "data.external.image": {
-                    "type": "external",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "-",
-                        "attributes": {
-                            "id": "-",
-                            "program.#": "6",
-                            "program.0": "python3",
-                            "program.1": "/usr/local/google/home/smcgruer/github/wpt.live/.terraform/modules/87f2a1166309de9f25a6d62f9940f267/latest-image.py",
-                            "program.2": "--registry",
-                            "program.3": "gcr.io",
-                            "program.4": "--image",
-                            "program.5": "wpt-live/wpt-live-wpt-server-tot",
-                            "result.%": "2",
-                            "result.identifier": "sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe",
-                            "result.time_created": "1610631609527"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.external"
-                }
-            },
-            "depends_on": []
-        },
-        {
-            "path": [
-                "root",
-                "wpt-live",
-                "cert-renewer-container"
-            ],
-            "outputs": {
-                "container": {
-                    "sensitive": false,
-                    "type": "map",
-                    "value": {
-                        "env": [
-                            {
-                                "name": "WPT_HOST",
-                                "value": "wpt.live"
-                            },
-                            {
-                                "name": "WPT_ALT_HOST",
-                                "value": "not-wpt.live"
-                            },
-                            {
-                                "name": "WPT_BUCKET",
-                                "value": "wpt-tot-certificates"
-                            }
-                        ],
-                        "image": "gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5"
-                    }
-                },
-                "metadata_key": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "gce-container-declaration"
-                },
-                "metadata_value": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\n  restartPolicy: Always\n  volumes: []\n"
-                },
-                "restart_policy": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "Always"
-                },
-                "source_image": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-85-13310-1209-17"
-                },
-                "vm_container_label": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "cos-stable-85-13310-1209-17"
-                },
-                "vm_container_label_key": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "container-vm"
-                },
-                "volumes": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": []
-                }
-            },
-            "resources": {
-                "data.external.spec_as_yaml": {
-                    "type": "external",
-                    "depends_on": [
-                        "local.spec"
-                    ],
-                    "primary": {
-                        "id": "-",
-                        "attributes": {
-                            "id": "-",
-                            "program.#": "2",
-                            "program.0": "ruby",
-                            "program.1": "/usr/local/google/home/smcgruer/github/wpt.live/.terraform/modules/34dbc0d0ce584c6ae6982d1d38b3c9f6/helpers/map_to_yaml.rb",
-                            "query.%": "1",
-                            "query.root": "{\"spec\":{\"containers\":[{\"env\":[{\"name\":\"WPT_HOST\",\"value\":\"wpt.live\"},{\"name\":\"WPT_ALT_HOST\",\"value\":\"not-wpt.live\"},{\"name\":\"WPT_BUCKET\",\"value\":\"wpt-tot-certificates\"}],\"image\":\"gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\"}],\"restartPolicy\":\"Always\",\"volumes\":[]}}",
-                            "result.%": "1",
-                            "result.rendered": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\n  restartPolicy: Always\n  volumes: []\n"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.external"
-                },
-                "data.google_compute_image.coreos": {
-                    "type": "google_compute_image",
-                    "depends_on": [
-                        "local.coreos_image_family",
-                        "local.coreos_project"
-                    ],
-                    "primary": {
-                        "id": "cos-cloud/family/cos-stable",
-                        "attributes": {
-                            "archive_size_bytes": "1146975552",
-                            "creation_timestamp": "2021-03-01T17:22:31.546-08:00",
-                            "description": "Google, Container-Optimized OS, 85-13310.1209.17 stable, Kernel: ChromiumOS-5.4.89 Kubernetes: 1.18.13 Docker: 19.03.14 Family: cos-stable, supports Shielded VM features, supports Confidential VM features on N2D",
-                            "disk_size_gb": "10",
-                            "family": "cos-stable",
-                            "id": "cos-cloud/family/cos-stable",
-                            "image_encryption_key_sha256": "",
-                            "image_id": "4298363518816628152",
-                            "label_fingerprint": "2XGyCciYJhA=",
-                            "labels.%": "2",
-                            "labels.build_number": "13310-1209-17",
-                            "labels.milestone": "85",
-                            "licenses.#": "3",
-                            "licenses.0": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos-pcid",
-                            "licenses.1": "https://www.googleapis.com/compute/v1/projects/cos-cloud-shielded/global/licenses/shielded-cos",
-                            "licenses.2": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos",
-                            "name": "cos-stable-85-13310-1209-17",
-                            "project": "cos-cloud",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-85-13310-1209-17",
-                            "source_disk": "",
-                            "source_disk_encryption_key_sha256": "",
-                            "source_disk_id": "",
-                            "source_image_id": "",
-                            "status": "READY"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                }
-            },
-            "depends_on": []
-        },
-        {
-            "path": [
-                "root",
-                "wpt-live",
-                "cert-renewers"
-            ],
-            "outputs": {
-                "depends_id": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "929056379834909265"
-                },
-                "health_check": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": ""
-                },
-                "instance_group": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-cert-renewers"
-                },
-                "instance_template": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001"
-                    ]
-                },
-                "instances": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        [
-                            "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instances/wpt-tot-cert-renewers-g7cx"
-                        ]
-                    ]
-                },
-                "name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "wpt-tot-cert-renewers"
-                },
-                "network_ip": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": ""
-                },
-                "region_depends_id": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": ""
-                },
-                "region_instance_group": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": ""
-                },
-                "service_port": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "8004"
-                },
-                "service_port_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "http"
-                },
-                "target_tags": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        "wpt-tot-allow"
-                    ]
-                }
-            },
-            "resources": {
-                "data.google_compute_instance_group.zonal": {
-                    "type": "google_compute_instance_group",
-                    "depends_on": [
-                        "google_compute_instance_group_manager.default.*",
-                        "local.dependency_id"
-                    ],
-                    "primary": {
-                        "id": "us-central1-b/wpt-tot-cert-renewers",
-                        "attributes": {
-                            "description": "This instance group is controlled by Instance Group Manager 'wpt-tot-cert-renewers'. To modify instances in this group, use the Instance Group Manager API: https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers",
-                            "id": "us-central1-b/wpt-tot-cert-renewers",
-                            "instances.#": "1",
-                            "instances.1607880077": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instances/wpt-tot-cert-renewers-g7cx",
-                            "name": "wpt-tot-cert-renewers",
-                            "named_port.#": "1",
-                            "named_port.0.name": "http",
-                            "named_port.0.port": "8004",
-                            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-cert-renewers",
-                            "size": "1",
-                            "zone": "us-central1-b"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "data.google_compute_zones.available": {
-                    "type": "google_compute_zones",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "2021-03-15 17:37:37.551715362 +0000 UTC",
-                        "attributes": {
-                            "id": "2021-03-15 17:37:37.551715362 +0000 UTC",
-                            "names.#": "4",
-                            "names.0": "us-central1-a",
-                            "names.1": "us-central1-b",
-                            "names.2": "us-central1-c",
-                            "names.3": "us-central1-f",
-                            "project": "wpt-live",
-                            "region": "us-central1"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_instance_group_manager.default": {
-                    "type": "google_compute_instance_group_manager",
-                    "depends_on": [
-                        "google_compute_health_check.mig-health-check.*",
-                        "google_compute_instance_template.default"
-                    ],
-                    "primary": {
-                        "id": "wpt-live/us-central1-b/wpt-tot-cert-renewers",
-                        "attributes": {
-                            "auto_healing_policies.#": "1",
-                            "auto_healing_policies.0.health_check": "",
-                            "auto_healing_policies.0.initial_delay_sec": "30",
-                            "base_instance_name": "wpt-tot-cert-renewers",
-                            "description": "compute VM Instance Group",
-                            "fingerprint": "PZRcriJmcPg=",
-                            "id": "wpt-live/us-central1-b/wpt-tot-cert-renewers",
-                            "instance_group": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-cert-renewers",
-                            "name": "wpt-tot-cert-renewers",
-                            "named_port.#": "1",
-                            "named_port.1374678711.name": "http",
-                            "named_port.1374678711.port": "8004",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroupManagers/wpt-tot-cert-renewers",
-                            "target_pools.#": "0",
-                            "target_size": "1",
-                            "update_policy.#": "1",
-                            "update_policy.0.max_surge_fixed": "1",
-                            "update_policy.0.max_surge_percent": "0",
-                            "update_policy.0.max_unavailable_fixed": "1",
-                            "update_policy.0.max_unavailable_percent": "0",
-                            "update_policy.0.min_ready_sec": "0",
-                            "update_policy.0.minimal_action": "RESTART",
-                            "update_policy.0.type": "PROACTIVE",
-                            "version.#": "1",
-                            "version.0.instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001",
-                            "version.0.name": "wpt-tot-cert-renewers-default",
-                            "version.0.target_size.#": "0",
-                            "wait_for_instances": "false",
-                            "zone": "us-central1-b"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 300000000000,
-                                "delete": 900000000000,
-                                "update": 300000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google-beta"
-                },
-                "google_compute_instance_template.default": {
-                    "type": "google_compute_instance_template",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "default-20210315172233921500000001",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "description": "",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.boot": "true",
-                            "disk.0.device_name": "persistent-disk-0",
-                            "disk.0.disk_encryption_key.#": "0",
-                            "disk.0.disk_name": "",
-                            "disk.0.disk_size_gb": "0",
-                            "disk.0.disk_type": "pd-ssd",
-                            "disk.0.interface": "SCSI",
-                            "disk.0.labels.%": "0",
-                            "disk.0.mode": "READ_WRITE",
-                            "disk.0.source": "",
-                            "disk.0.source_image": "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17",
-                            "disk.0.type": "PERSISTENT",
-                            "id": "default-20210315172233921500000001",
-                            "instance_description": "",
-                            "labels.%": "1",
-                            "labels.container-vm": "cos-stable-85-13310-1209-17",
-                            "machine_type": "f1-micro",
-                            "metadata.%": "4",
-                            "metadata.gce-container-declaration": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\n  restartPolicy: Always\n  volumes: []\n",
-                            "metadata.google-logging-enabled": "true",
-                            "metadata.startup-script": "",
-                            "metadata.tf_depends_id": "",
-                            "metadata_fingerprint": "J6IpzJ9_WzA=",
-                            "min_cpu_platform": "",
-                            "name": "default-20210315172233921500000001",
-                            "name_prefix": "default-",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "1",
-                            "network_interface.0.access_config.0.assigned_nat_ip": "",
-                            "network_interface.0.access_config.0.nat_ip": "",
-                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
-                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
-                            "network_interface.0.address": "",
-                            "network_interface.0.alias_ip_range.#": "0",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "network_interface.0.network_ip": "",
-                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork",
-                            "network_interface.0.subnetwork_project": "wpt-live",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "scheduling.#": "1",
-                            "scheduling.0.automatic_restart": "true",
-                            "scheduling.0.node_affinities.#": "0",
-                            "scheduling.0.on_host_maintenance": "MIGRATE",
-                            "scheduling.0.preemptible": "false",
-                            "self_link": "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001",
-                            "service_account.#": "1",
-                            "service_account.0.email": "default",
-                            "service_account.0.scopes.#": "1",
-                            "service_account.0.scopes.1733087937": "https://www.googleapis.com/auth/cloud-platform",
-                            "tags.#": "2",
-                            "tags.2542268873": "allow-ssh",
-                            "tags.2803589456": "wpt-tot-allow",
-                            "tags_fingerprint": ""
-                        },
-                        "meta": {
-                            "schema_version": "1"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "null_resource.dummy_dependency": {
-                    "type": "null_resource",
-                    "depends_on": [
-                        "google_compute_instance_group_manager.default",
-                        "google_compute_instance_template.default.*"
-                    ],
-                    "primary": {
-                        "id": "929056379834909265",
-                        "attributes": {
-                            "id": "929056379834909265",
-                            "triggers.%": "1",
-                            "triggers.instance_template": "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.null"
-                }
-            },
-            "depends_on": []
-        },
-        {
-            "path": [
-                "root",
-                "wpt-live",
-                "wpt-server-container"
-            ],
-            "outputs": {
-                "container": {
-                    "sensitive": false,
-                    "type": "map",
-                    "value": {
-                        "env": [
-                            {
-                                "name": "WPT_HOST",
-                                "value": "wpt.live"
-                            },
-                            {
-                                "name": "WPT_ALT_HOST",
-                                "value": "not-wpt.live"
-                            },
-                            {
-                                "name": "WPT_BUCKET",
-                                "value": "wpt-tot-certificates"
-                            }
-                        ],
-                        "image": "gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe"
-                    }
-                },
-                "metadata_key": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "gce-container-declaration"
-                },
-                "metadata_value": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\n  restartPolicy: Always\n  volumes: []\n"
-                },
-                "restart_policy": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "Always"
-                },
-                "source_image": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-85-13310-1209-17"
-                },
-                "vm_container_label": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "cos-stable-85-13310-1209-17"
-                },
-                "vm_container_label_key": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "container-vm"
-                },
-                "volumes": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": []
-                }
-            },
-            "resources": {
-                "data.external.spec_as_yaml": {
-                    "type": "external",
-                    "depends_on": [
-                        "local.spec"
-                    ],
-                    "primary": {
-                        "id": "-",
-                        "attributes": {
-                            "id": "-",
-                            "program.#": "2",
-                            "program.0": "ruby",
-                            "program.1": "/usr/local/google/home/smcgruer/github/wpt.live/.terraform/modules/0c3ecb6d825cdcbf43c2a8ee2bf5dd9a/helpers/map_to_yaml.rb",
-                            "query.%": "1",
-                            "query.root": "{\"spec\":{\"containers\":[{\"env\":[{\"name\":\"WPT_HOST\",\"value\":\"wpt.live\"},{\"name\":\"WPT_ALT_HOST\",\"value\":\"not-wpt.live\"},{\"name\":\"WPT_BUCKET\",\"value\":\"wpt-tot-certificates\"}],\"image\":\"gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\"}],\"restartPolicy\":\"Always\",\"volumes\":[]}}",
-                            "result.%": "1",
-                            "result.rendered": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\n  restartPolicy: Always\n  volumes: []\n"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.external"
-                },
-                "data.google_compute_image.coreos": {
-                    "type": "google_compute_image",
-                    "depends_on": [
-                        "local.coreos_image_family",
-                        "local.coreos_project"
-                    ],
-                    "primary": {
-                        "id": "cos-cloud/family/cos-stable",
-                        "attributes": {
-                            "archive_size_bytes": "1146975552",
-                            "creation_timestamp": "2021-03-01T17:22:31.546-08:00",
-                            "description": "Google, Container-Optimized OS, 85-13310.1209.17 stable, Kernel: ChromiumOS-5.4.89 Kubernetes: 1.18.13 Docker: 19.03.14 Family: cos-stable, supports Shielded VM features, supports Confidential VM features on N2D",
-                            "disk_size_gb": "10",
-                            "family": "cos-stable",
-                            "id": "cos-cloud/family/cos-stable",
-                            "image_encryption_key_sha256": "",
-                            "image_id": "4298363518816628152",
-                            "label_fingerprint": "2XGyCciYJhA=",
-                            "labels.%": "2",
-                            "labels.build_number": "13310-1209-17",
-                            "labels.milestone": "85",
-                            "licenses.#": "3",
-                            "licenses.0": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos-pcid",
-                            "licenses.1": "https://www.googleapis.com/compute/v1/projects/cos-cloud-shielded/global/licenses/shielded-cos",
-                            "licenses.2": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos",
-                            "name": "cos-stable-85-13310-1209-17",
-                            "project": "cos-cloud",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-85-13310-1209-17",
-                            "source_disk": "",
-                            "source_disk_encryption_key_sha256": "",
-                            "source_disk_id": "",
-                            "source_image_id": "",
-                            "status": "READY"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                }
-            },
-            "depends_on": []
-        },
-        {
-            "path": [
-                "root",
-                "wpt-live",
-                "wpt-servers"
-            ],
-            "outputs": {
-                "depends_id": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "974901135113459607"
-                },
-                "health_check": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/healthChecks/wpt-tot-wpt-servers"
-                },
-                "instance_group": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-wpt-servers"
-                },
-                "instance_template": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002"
-                    ]
-                },
-                "instances": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        [
-                            "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instances/wpt-tot-wpt-servers-56g3",
-                            "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instances/wpt-tot-wpt-servers-kgdh"
-                        ]
-                    ]
-                },
-                "name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "wpt-tot-wpt-servers"
-                },
-                "network_ip": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": ""
-                },
-                "region_depends_id": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": ""
-                },
-                "region_instance_group": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": ""
-                },
-                "service_port_1": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "80"
-                },
-                "service_port_1_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "http-primary"
-                },
-                "service_port_2": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "8000"
-                },
-                "service_port_2_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "http-secondary"
-                },
-                "service_port_3": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "443"
-                },
-                "service_port_3_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "https"
-                },
-                "service_port_4": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "8001"
-                },
-                "service_port_4_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "http2"
-                },
-                "service_port_5": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "8002"
-                },
-                "service_port_5_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "websocket"
-                },
-                "service_port_6": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "8003"
-                },
-                "service_port_6_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "websocket-secure"
-                },
-                "service_port_7": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "8443"
-                },
-                "service_port_7_name": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "https-secondary"
-                },
-                "target_tags": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        "wpt-tot-allow"
-                    ]
-                }
-            },
-            "resources": {
-                "data.google_compute_instance_group.zonal": {
-                    "type": "google_compute_instance_group",
-                    "depends_on": [
-                        "google_compute_instance_group_manager.default.*",
-                        "local.dependency_id"
-                    ],
-                    "primary": {
-                        "id": "us-central1-b/wpt-tot-wpt-servers",
-                        "attributes": {
-                            "description": "This instance group is controlled by Instance Group Manager 'wpt-tot-wpt-servers'. To modify instances in this group, use the Instance Group Manager API: https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers",
-                            "id": "us-central1-b/wpt-tot-wpt-servers",
-                            "instances.#": "2",
-                            "instances.1371850345": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instances/wpt-tot-wpt-servers-56g3",
-                            "instances.3237749184": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instances/wpt-tot-wpt-servers-kgdh",
-                            "name": "wpt-tot-wpt-servers",
-                            "named_port.#": "7",
-                            "named_port.0.name": "https-secondary",
-                            "named_port.0.port": "8443",
-                            "named_port.1.name": "http2",
-                            "named_port.1.port": "8001",
-                            "named_port.2.name": "http-primary",
-                            "named_port.2.port": "80",
-                            "named_port.3.name": "http-secondary",
-                            "named_port.3.port": "8000",
-                            "named_port.4.name": "websocket",
-                            "named_port.4.port": "8002",
-                            "named_port.5.name": "https",
-                            "named_port.5.port": "443",
-                            "named_port.6.name": "websocket-secure",
-                            "named_port.6.port": "8003",
-                            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-wpt-servers",
-                            "size": "2",
-                            "zone": "us-central1-b"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "data.google_compute_zones.available": {
-                    "type": "google_compute_zones",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "2021-03-15 17:37:37.497693006 +0000 UTC",
-                        "attributes": {
-                            "id": "2021-03-15 17:37:37.497693006 +0000 UTC",
-                            "names.#": "4",
-                            "names.0": "us-central1-a",
-                            "names.1": "us-central1-b",
-                            "names.2": "us-central1-c",
-                            "names.3": "us-central1-f",
-                            "project": "wpt-live",
-                            "region": "us-central1"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_firewall.default-ssh": {
-                    "type": "google_compute_firewall",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "wpt-tot-wpt-servers-vm-ssh",
-                        "attributes": {
-                            "allow.#": "1",
-                            "allow.803338340.ports.#": "1",
-                            "allow.803338340.ports.0": "22",
-                            "allow.803338340.protocol": "tcp",
-                            "creation_timestamp": "2020-07-27T06:54:16.067-07:00",
-                            "deny.#": "0",
-                            "description": "",
-                            "destination_ranges.#": "0",
-                            "direction": "INGRESS",
-                            "disabled": "false",
-                            "id": "wpt-tot-wpt-servers-vm-ssh",
-                            "name": "wpt-tot-wpt-servers-vm-ssh",
-                            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "priority": "1000",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/firewalls/wpt-tot-wpt-servers-vm-ssh",
-                            "source_ranges.#": "1",
-                            "source_ranges.1080289494": "0.0.0.0/0",
-                            "source_service_accounts.#": "0",
-                            "source_tags.#": "0",
-                            "target_service_accounts.#": "0",
-                            "target_tags.#": "1",
-                            "target_tags.2542268873": "allow-ssh"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            },
-                            "schema_version": "1"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_firewall.mig-health-check": {
-                    "type": "google_compute_firewall",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "wpt-tot-wpt-servers-vm-hc",
-                        "attributes": {
-                            "allow.#": "1",
-                            "allow.680193008.ports.#": "1",
-                            "allow.680193008.ports.0": "443",
-                            "allow.680193008.protocol": "tcp",
-                            "creation_timestamp": "2019-10-30T15:49:57.561-07:00",
-                            "deny.#": "0",
-                            "description": "",
-                            "destination_ranges.#": "0",
-                            "direction": "INGRESS",
-                            "disabled": "false",
-                            "id": "wpt-tot-wpt-servers-vm-hc",
-                            "name": "wpt-tot-wpt-servers-vm-hc",
-                            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "priority": "1000",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/firewalls/wpt-tot-wpt-servers-vm-hc",
-                            "source_ranges.#": "2",
-                            "source_ranges.2192388802": "130.211.0.0/22",
-                            "source_ranges.2394378644": "35.191.0.0/16",
-                            "source_service_accounts.#": "0",
-                            "source_tags.#": "0",
-                            "target_service_accounts.#": "0",
-                            "target_tags.#": "1",
-                            "target_tags.2803589456": "wpt-tot-allow"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            },
-                            "schema_version": "1"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_health_check.mig-health-check": {
-                    "type": "google_compute_health_check",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "wpt-tot-wpt-servers",
-                        "attributes": {
-                            "check_interval_sec": "10",
-                            "creation_timestamp": "2019-10-30T15:49:41.925-07:00",
-                            "description": "",
-                            "healthy_threshold": "3",
-                            "http2_health_check.#": "0",
-                            "http_health_check.#": "0",
-                            "https_health_check.#": "1",
-                            "https_health_check.0.host": "",
-                            "https_health_check.0.port": "443",
-                            "https_health_check.0.port_name": "",
-                            "https_health_check.0.port_specification": "",
-                            "https_health_check.0.proxy_header": "NONE",
-                            "https_health_check.0.request_path": "/?gcp-health-check",
-                            "https_health_check.0.response": "",
-                            "id": "wpt-tot-wpt-servers",
-                            "name": "wpt-tot-wpt-servers",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/healthChecks/wpt-tot-wpt-servers",
-                            "ssl_health_check.#": "0",
-                            "tcp_health_check.#": "0",
-                            "timeout_sec": "10",
-                            "type": "HTTPS",
-                            "unhealthy_threshold": "6"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 240000000000,
-                                "delete": 240000000000,
-                                "update": 240000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_instance_group_manager.default": {
-                    "type": "google_compute_instance_group_manager",
-                    "depends_on": [
-                        "google_compute_health_check.mig-health-check.*",
-                        "google_compute_instance_template.default"
-                    ],
-                    "primary": {
-                        "id": "wpt-live/us-central1-b/wpt-tot-wpt-servers",
-                        "attributes": {
-                            "auto_healing_policies.#": "1",
-                            "auto_healing_policies.0.health_check": "https://www.googleapis.com/compute/beta/projects/wpt-live/global/healthChecks/wpt-tot-wpt-servers",
-                            "auto_healing_policies.0.initial_delay_sec": "30",
-                            "base_instance_name": "wpt-tot-wpt-servers",
-                            "description": "compute VM Instance Group",
-                            "fingerprint": "mbIYjaTil1M=",
-                            "id": "wpt-live/us-central1-b/wpt-tot-wpt-servers",
-                            "instance_group": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-wpt-servers",
-                            "name": "wpt-tot-wpt-servers",
-                            "named_port.#": "7",
-                            "named_port.1981194066.name": "https-secondary",
-                            "named_port.1981194066.port": "8443",
-                            "named_port.2276636974.name": "http2",
-                            "named_port.2276636974.port": "8001",
-                            "named_port.2721583918.name": "http-primary",
-                            "named_port.2721583918.port": "80",
-                            "named_port.3173555449.name": "http-secondary",
-                            "named_port.3173555449.port": "8000",
-                            "named_port.4259663301.name": "websocket",
-                            "named_port.4259663301.port": "8002",
-                            "named_port.613541658.name": "https",
-                            "named_port.613541658.port": "443",
-                            "named_port.862847079.name": "websocket-secure",
-                            "named_port.862847079.port": "8003",
-                            "project": "wpt-live",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroupManagers/wpt-tot-wpt-servers",
-                            "target_pools.#": "1",
-                            "target_pools.1392826747": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
-                            "target_size": "2",
-                            "update_policy.#": "1",
-                            "update_policy.0.max_surge_fixed": "0",
-                            "update_policy.0.max_surge_percent": "0",
-                            "update_policy.0.max_unavailable_fixed": "1",
-                            "update_policy.0.max_unavailable_percent": "0",
-                            "update_policy.0.min_ready_sec": "0",
-                            "update_policy.0.minimal_action": "RESTART",
-                            "update_policy.0.type": "PROACTIVE",
-                            "version.#": "1",
-                            "version.0.instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002",
-                            "version.0.name": "wpt-tot-wpt-servers-default",
-                            "version.0.target_size.#": "0",
-                            "wait_for_instances": "false",
-                            "zone": "us-central1-b"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 300000000000,
-                                "delete": 900000000000,
-                                "update": 300000000000
-                            }
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google-beta"
-                },
-                "google_compute_instance_template.default": {
-                    "type": "google_compute_instance_template",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "default-20210315172234903400000002",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "description": "",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.boot": "true",
-                            "disk.0.device_name": "persistent-disk-0",
-                            "disk.0.disk_encryption_key.#": "0",
-                            "disk.0.disk_name": "",
-                            "disk.0.disk_size_gb": "0",
-                            "disk.0.disk_type": "pd-ssd",
-                            "disk.0.interface": "SCSI",
-                            "disk.0.labels.%": "0",
-                            "disk.0.mode": "READ_WRITE",
-                            "disk.0.source": "",
-                            "disk.0.source_image": "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17",
-                            "disk.0.type": "PERSISTENT",
-                            "id": "default-20210315172234903400000002",
-                            "instance_description": "",
-                            "labels.%": "1",
-                            "labels.container-vm": "cos-stable-85-13310-1209-17",
-                            "machine_type": "e2-medium",
-                            "metadata.%": "4",
-                            "metadata.gce-container-declaration": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\n  restartPolicy: Always\n  volumes: []\n",
-                            "metadata.google-logging-enabled": "true",
-                            "metadata.startup-script": "",
-                            "metadata.tf_depends_id": "",
-                            "metadata_fingerprint": "g4OlLs3l5Rc=",
-                            "min_cpu_platform": "",
-                            "name": "default-20210315172234903400000002",
-                            "name_prefix": "default-",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "1",
-                            "network_interface.0.access_config.0.assigned_nat_ip": "",
-                            "network_interface.0.access_config.0.nat_ip": "",
-                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
-                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
-                            "network_interface.0.address": "",
-                            "network_interface.0.alias_ip_range.#": "0",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
-                            "network_interface.0.network_ip": "",
-                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork",
-                            "network_interface.0.subnetwork_project": "wpt-live",
-                            "project": "wpt-live",
-                            "region": "us-central1",
-                            "scheduling.#": "1",
-                            "scheduling.0.automatic_restart": "true",
-                            "scheduling.0.node_affinities.#": "0",
-                            "scheduling.0.on_host_maintenance": "MIGRATE",
-                            "scheduling.0.preemptible": "false",
-                            "self_link": "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002",
-                            "service_account.#": "1",
-                            "service_account.0.email": "default",
-                            "service_account.0.scopes.#": "2",
-                            "service_account.0.scopes.1632638332": "https://www.googleapis.com/auth/devstorage.read_only",
-                            "service_account.0.scopes.172152165": "https://www.googleapis.com/auth/logging.write",
-                            "tags.#": "2",
-                            "tags.2542268873": "allow-ssh",
-                            "tags.2803589456": "wpt-tot-allow",
-                            "tags_fingerprint": ""
-                        },
-                        "meta": {
-                            "schema_version": "1"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "null_resource.dummy_dependency": {
-                    "type": "null_resource",
-                    "depends_on": [
-                        "google_compute_instance_group_manager.default",
-                        "google_compute_instance_template.default.*"
-                    ],
-                    "primary": {
-                        "id": "974901135113459607",
-                        "attributes": {
-                            "id": "974901135113459607",
-                            "triggers.%": "1",
-                            "triggers.instance_template": "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.null"
-                }
-            },
-            "depends_on": []
+          "schema_version": 0,
+          "attributes": {
+            "auto_create_subnetworks": false,
+            "delete_default_routes_on_create": false,
+            "description": "",
+            "enable_ula_internal_ipv6": false,
+            "gateway_ipv4": "",
+            "id": "wpt-live-network",
+            "internal_ipv6_range": "",
+            "mtu": 0,
+            "name": "wpt-live-network",
+            "project": "wpt-live",
+            "routing_mode": "REGIONAL",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "create_before_destroy": true
         }
-    ]
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_subnetwork",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-10-30T15:49:56.487-07:00",
+            "description": "",
+            "external_ipv6_prefix": "",
+            "fingerprint": "_4CEx9NGrfE=",
+            "gateway_address": "10.127.0.1",
+            "id": "us-central1/wpt-live-subnetwork",
+            "ip_cidr_range": "10.127.0.0/20",
+            "ipv6_access_type": "",
+            "ipv6_cidr_range": "",
+            "log_config": [],
+            "name": "wpt-live-subnetwork",
+            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
+            "private_ip_google_access": true,
+            "private_ipv6_google_access": "DISABLE_GOOGLE_ACCESS",
+            "project": "wpt-live",
+            "purpose": "PRIVATE",
+            "region": "us-central1",
+            "role": "",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork",
+            "stack_type": "IPV4_ONLY",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.default"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.cert-renewer-image",
+      "mode": "data",
+      "type": "external",
+      "name": "image",
+      "provider": "provider[\"registry.terraform.io/hashicorp/external\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "-",
+            "program": [
+              "python3",
+              "infrastructure/docker-image/latest-image.py",
+              "--registry",
+              "gcr.io",
+              "--image",
+              "wpt-live/wpt-live-cert-renewer"
+            ],
+            "query": null,
+            "result": {
+              "identifier": "sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5",
+              "time_created": "1570479055243"
+            },
+            "working_dir": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "data",
+      "type": "google_dns_managed_zone",
+      "name": "alt_host",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "",
+            "dns_name": "not-wpt.live.",
+            "id": "projects/wpt-live/managedZones/not-wpt-live",
+            "name": "not-wpt-live",
+            "name_servers": [
+              "ns-cloud-a1.googledomains.com.",
+              "ns-cloud-a2.googledomains.com.",
+              "ns-cloud-a3.googledomains.com.",
+              "ns-cloud-a4.googledomains.com."
+            ],
+            "project": "wpt-live",
+            "visibility": "public"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "data",
+      "type": "google_dns_managed_zone",
+      "name": "host",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "",
+            "dns_name": "wpt.live.",
+            "id": "projects/wpt-live/managedZones/wpt-live",
+            "name": "wpt-live",
+            "name_servers": [
+              "ns-cloud-b1.googledomains.com.",
+              "ns-cloud-b2.googledomains.com.",
+              "ns-cloud-b3.googledomains.com.",
+              "ns-cloud-b4.googledomains.com."
+            ],
+            "project": "wpt-live",
+            "visibility": "public"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_address",
+      "name": "web-platform-tests-live-address",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "address": "35.223.122.27",
+            "address_type": "EXTERNAL",
+            "creation_timestamp": "2019-10-30T15:49:38.932-07:00",
+            "description": "",
+            "id": "wpt-live/us-central1/wpt-tot-address",
+            "name": "wpt-tot-address",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "prefix_length": 0,
+            "project": "wpt-live",
+            "purpose": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/addresses/wpt-tot-address",
+            "subnetwork": "",
+            "timeouts": {
+              "create": null,
+              "delete": null
+            },
+            "users": [
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-0",
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-3",
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-5",
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-2",
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-4",
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-1",
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-6"
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwfX0="
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "default-lb-fw",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "80",
+                  "8000",
+                  "443",
+                  "8001",
+                  "8002",
+                  "8003",
+                  "8443"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2019-10-30T15:49:56.982-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "wpt-tot-load-balancing-vm-service",
+            "log_config": [],
+            "name": "wpt-tot-load-balancing-vm-service",
+            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
+            "priority": 1000,
+            "project": "wpt-live",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/firewalls/wpt-tot-load-balancing-vm-service",
+            "source_ranges": [
+              "0.0.0.0/0"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [
+              "wpt-tot-allow"
+            ],
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.default"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "wpt-server-mig-health-check",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "443"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2019-10-30T15:49:57.561-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "wpt-tot-wpt-servers-vm-hc",
+            "log_config": [],
+            "name": "wpt-tot-wpt-servers-vm-hc",
+            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
+            "priority": 1000,
+            "project": "wpt-live",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/firewalls/wpt-tot-wpt-servers-vm-hc",
+            "source_ranges": [
+              "130.211.0.0/22",
+              "35.191.0.0/16"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [
+              "wpt-tot-allow"
+            ],
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.default"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "wpt-servers-default-ssh",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "22"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2020-07-27T06:54:16.067-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "wpt-tot-wpt-servers-vm-ssh",
+            "log_config": [],
+            "name": "wpt-tot-wpt-servers-vm-ssh",
+            "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
+            "priority": 1000,
+            "project": "wpt-live",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/firewalls/wpt-tot-wpt-servers-vm-ssh",
+            "source_ranges": [
+              "0.0.0.0/0"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [
+              "allow-ssh"
+            ],
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.default"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_forwarding_rule",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "all_ports": false,
+            "allow_global_access": false,
+            "backend_service": "",
+            "creation_timestamp": "2019-10-30T15:49:46.570-07:00",
+            "description": "",
+            "id": "wpt-tot-load-balancing-0",
+            "ip_address": "35.223.122.27",
+            "ip_protocol": "TCP",
+            "is_mirroring_collector": false,
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "wpt-tot-load-balancing-0",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "port_range": "80-80",
+            "ports": [],
+            "project": "wpt-live",
+            "psc_connection_id": "",
+            "psc_connection_status": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-0",
+            "service_directory_registrations": [],
+            "service_label": "",
+            "service_name": "",
+            "subnetwork": "",
+            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_target_pool.default"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "all_ports": false,
+            "allow_global_access": false,
+            "backend_service": "",
+            "creation_timestamp": "2019-10-30T15:49:50.318-07:00",
+            "description": "",
+            "id": "wpt-tot-load-balancing-1",
+            "ip_address": "35.223.122.27",
+            "ip_protocol": "TCP",
+            "is_mirroring_collector": false,
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "wpt-tot-load-balancing-1",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "port_range": "8000-8000",
+            "ports": [],
+            "project": "wpt-live",
+            "psc_connection_id": "",
+            "psc_connection_status": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-1",
+            "service_directory_registrations": [],
+            "service_label": "",
+            "service_name": "",
+            "subnetwork": "",
+            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_target_pool.default"
+          ]
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "all_ports": false,
+            "allow_global_access": false,
+            "backend_service": "",
+            "creation_timestamp": "2019-10-30T15:49:48.236-07:00",
+            "description": "",
+            "id": "wpt-tot-load-balancing-2",
+            "ip_address": "35.223.122.27",
+            "ip_protocol": "TCP",
+            "is_mirroring_collector": false,
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "wpt-tot-load-balancing-2",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "port_range": "443-443",
+            "ports": [],
+            "project": "wpt-live",
+            "psc_connection_id": "",
+            "psc_connection_status": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-2",
+            "service_directory_registrations": [],
+            "service_label": "",
+            "service_name": "",
+            "subnetwork": "",
+            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_target_pool.default"
+          ]
+        },
+        {
+          "index_key": 3,
+          "schema_version": 0,
+          "attributes": {
+            "all_ports": false,
+            "allow_global_access": false,
+            "backend_service": "",
+            "creation_timestamp": "2019-10-30T15:49:47.101-07:00",
+            "description": "",
+            "id": "wpt-tot-load-balancing-3",
+            "ip_address": "35.223.122.27",
+            "ip_protocol": "TCP",
+            "is_mirroring_collector": false,
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "wpt-tot-load-balancing-3",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "port_range": "8001-8001",
+            "ports": [],
+            "project": "wpt-live",
+            "psc_connection_id": "",
+            "psc_connection_status": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-3",
+            "service_directory_registrations": [],
+            "service_label": "",
+            "service_name": "",
+            "subnetwork": "",
+            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_target_pool.default"
+          ]
+        },
+        {
+          "index_key": 4,
+          "schema_version": 0,
+          "attributes": {
+            "all_ports": false,
+            "allow_global_access": false,
+            "backend_service": "",
+            "creation_timestamp": "2019-10-30T15:49:49.208-07:00",
+            "description": "",
+            "id": "wpt-tot-load-balancing-4",
+            "ip_address": "35.223.122.27",
+            "ip_protocol": "TCP",
+            "is_mirroring_collector": false,
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "wpt-tot-load-balancing-4",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "port_range": "8002-8002",
+            "ports": [],
+            "project": "wpt-live",
+            "psc_connection_id": "",
+            "psc_connection_status": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-4",
+            "service_directory_registrations": [],
+            "service_label": "",
+            "service_name": "",
+            "subnetwork": "",
+            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_target_pool.default"
+          ]
+        },
+        {
+          "index_key": 5,
+          "schema_version": 0,
+          "attributes": {
+            "all_ports": false,
+            "allow_global_access": false,
+            "backend_service": "",
+            "creation_timestamp": "2019-10-30T15:49:47.752-07:00",
+            "description": "",
+            "id": "wpt-tot-load-balancing-5",
+            "ip_address": "35.223.122.27",
+            "ip_protocol": "TCP",
+            "is_mirroring_collector": false,
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "wpt-tot-load-balancing-5",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "port_range": "8003-8003",
+            "ports": [],
+            "project": "wpt-live",
+            "psc_connection_id": "",
+            "psc_connection_status": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-5",
+            "service_directory_registrations": [],
+            "service_label": "",
+            "service_name": "",
+            "subnetwork": "",
+            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_target_pool.default"
+          ]
+        },
+        {
+          "index_key": 6,
+          "schema_version": 0,
+          "attributes": {
+            "all_ports": false,
+            "allow_global_access": false,
+            "backend_service": "",
+            "creation_timestamp": "2020-08-11T07:10:08.564-07:00",
+            "description": "",
+            "id": "wpt-tot-load-balancing-6",
+            "ip_address": "35.223.122.27",
+            "ip_protocol": "TCP",
+            "is_mirroring_collector": false,
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "wpt-tot-load-balancing-6",
+            "network": "",
+            "network_tier": "PREMIUM",
+            "port_range": "8443-8443",
+            "ports": [],
+            "project": "wpt-live",
+            "psc_connection_id": "",
+            "psc_connection_status": "",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/forwardingRules/wpt-tot-load-balancing-6",
+            "service_directory_registrations": [],
+            "service_label": "",
+            "service_name": "",
+            "subnetwork": "",
+            "target": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_target_pool.default"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_health_check",
+      "name": "wpt_health_check",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "check_interval_sec": 10,
+            "creation_timestamp": "2019-10-30T15:49:41.925-07:00",
+            "description": "",
+            "grpc_health_check": [],
+            "healthy_threshold": 3,
+            "http2_health_check": [],
+            "http_health_check": [],
+            "https_health_check": [
+              {
+                "host": "",
+                "port": 443,
+                "port_name": "",
+                "port_specification": "",
+                "proxy_header": "NONE",
+                "request_path": "/?gcp-health-check",
+                "response": ""
+              }
+            ],
+            "id": "wpt-tot-wpt-servers",
+            "log_config": [
+              {
+                "enable": false
+              }
+            ],
+            "name": "wpt-tot-wpt-servers",
+            "project": "wpt-live",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/healthChecks/wpt-tot-wpt-servers",
+            "ssl_health_check": [],
+            "tcp_health_check": [],
+            "timeout_sec": 10,
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            },
+            "type": "HTTPS",
+            "unhealthy_threshold": 6
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_http_health_check",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "check_interval_sec": 5,
+            "creation_timestamp": "2019-10-30T15:49:38.750-07:00",
+            "description": "",
+            "healthy_threshold": 2,
+            "host": "",
+            "id": "wpt-tot-load-balancing-health-check",
+            "name": "wpt-tot-load-balancing-health-check",
+            "port": 80,
+            "project": "wpt-live",
+            "request_path": "/?gcp-health-check-load-balancing",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/httpHealthChecks/wpt-tot-load-balancing-health-check",
+            "timeout_sec": 5,
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            },
+            "unhealthy_threshold": 2
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_instance_group_manager",
+      "name": "cert_renewers",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "auto_healing_policies": [],
+            "base_instance_name": "wpt-tot-cert-renewers",
+            "description": "compute VM Instance Group",
+            "fingerprint": "xnOZ4dOGZgQ=",
+            "id": "wpt-live/us-central1-b/wpt-tot-cert-renewers",
+            "instance_group": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-cert-renewers",
+            "name": "wpt-tot-cert-renewers",
+            "named_port": [
+              {
+                "name": "http",
+                "port": 8004
+              }
+            ],
+            "operation": null,
+            "project": "wpt-live",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroupManagers/wpt-tot-cert-renewers",
+            "stateful_disk": [],
+            "status": [
+              {
+                "is_stable": true,
+                "stateful": [
+                  {
+                    "has_stateful_config": false,
+                    "per_instance_configs": [
+                      {
+                        "all_effective": true
+                      }
+                    ]
+                  }
+                ],
+                "version_target": [
+                  {
+                    "is_reached": true
+                  }
+                ]
+              }
+            ],
+            "target_pools": [],
+            "target_size": 1,
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            },
+            "update_policy": [
+              {
+                "max_surge_fixed": 1,
+                "max_surge_percent": 0,
+                "max_unavailable_fixed": 1,
+                "max_unavailable_percent": 0,
+                "minimal_action": "RESTART",
+                "most_disruptive_allowed_action": "",
+                "replacement_method": "SUBSTITUTE",
+                "type": "OPPORTUNISTIC"
+              }
+            ],
+            "version": [
+              {
+                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001",
+                "name": "",
+                "target_size": []
+              }
+            ],
+            "wait_for_instances": false,
+            "wait_for_instances_status": "STABLE",
+            "zone": "us-central1-b"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjMwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.default",
+            "google_compute_subnetwork.default",
+            "module.cert-renewer-image.data.external.image",
+            "module.wpt-live.google_compute_instance_template.cert_renewers",
+            "module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_instance_group_manager",
+      "name": "wpt_servers",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "auto_healing_policies": [
+              {
+                "health_check": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/healthChecks/wpt-tot-wpt-servers",
+                "initial_delay_sec": 30
+              }
+            ],
+            "base_instance_name": "wpt-tot-wpt-servers",
+            "description": "compute VM Instance Group",
+            "fingerprint": "Tw0WgcKJoRY=",
+            "id": "wpt-live/us-central1-b/wpt-tot-wpt-servers",
+            "instance_group": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-wpt-servers",
+            "name": "wpt-tot-wpt-servers",
+            "named_port": [
+              {
+                "name": "http-primary",
+                "port": 80
+              },
+              {
+                "name": "http-secondary",
+                "port": 8000
+              },
+              {
+                "name": "http2",
+                "port": 8001
+              },
+              {
+                "name": "https",
+                "port": 443
+              },
+              {
+                "name": "https-secondary",
+                "port": 8443
+              },
+              {
+                "name": "websocket",
+                "port": 8002
+              },
+              {
+                "name": "websocket-secure",
+                "port": 8003
+              }
+            ],
+            "operation": null,
+            "project": "wpt-live",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroupManagers/wpt-tot-wpt-servers",
+            "stateful_disk": [],
+            "status": [
+              {
+                "is_stable": true,
+                "stateful": [
+                  {
+                    "has_stateful_config": false,
+                    "per_instance_configs": [
+                      {
+                        "all_effective": true
+                      }
+                    ]
+                  }
+                ],
+                "version_target": [
+                  {
+                    "is_reached": true
+                  }
+                ]
+              }
+            ],
+            "target_pools": [
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"
+            ],
+            "target_size": 2,
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            },
+            "update_policy": [
+              {
+                "max_surge_fixed": 0,
+                "max_surge_percent": 0,
+                "max_unavailable_fixed": 1,
+                "max_unavailable_percent": 0,
+                "minimal_action": "RESTART",
+                "most_disruptive_allowed_action": "",
+                "replacement_method": "SUBSTITUTE",
+                "type": "PROACTIVE"
+              }
+            ],
+            "version": [
+              {
+                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002",
+                "name": "wpt-tot-wpt-servers-default",
+                "target_size": []
+              }
+            ],
+            "wait_for_instances": false,
+            "wait_for_instances_status": "STABLE",
+            "zone": "us-central1-b"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjMwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.default",
+            "google_compute_subnetwork.default",
+            "module.wpt-live.google_compute_health_check.wpt_health_check",
+            "module.wpt-live.google_compute_http_health_check.default",
+            "module.wpt-live.google_compute_instance_template.wpt_server",
+            "module.wpt-live.google_compute_target_pool.default",
+            "module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos",
+            "module.wpt-server-tot-image.data.external.image"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_instance_template",
+      "name": "cert_renewers",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "advanced_machine_features": [],
+            "can_ip_forward": false,
+            "confidential_instance_config": [],
+            "description": "",
+            "disk": [
+              {
+                "auto_delete": true,
+                "boot": true,
+                "device_name": "persistent-disk-0",
+                "disk_encryption_key": [],
+                "disk_name": "",
+                "disk_size_gb": 0,
+                "disk_type": "pd-ssd",
+                "interface": "SCSI",
+                "labels": {},
+                "mode": "READ_WRITE",
+                "resource_policies": [],
+                "source": "",
+                "source_image": "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17",
+                "type": "PERSISTENT"
+              }
+            ],
+            "guest_accelerator": [],
+            "id": "default-20210315172233921500000001",
+            "instance_description": "",
+            "labels": {
+              "container-vm": "cos-stable-85-13310-1209-17"
+            },
+            "machine_type": "f1-micro",
+            "metadata": {
+              "gce-container-declaration": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\n  restartPolicy: Always\n  volumes: []\n",
+              "google-logging-enabled": "true",
+              "startup-script": "",
+              "tf_depends_id": ""
+            },
+            "metadata_fingerprint": "J6IpzJ9_WzA=",
+            "metadata_startup_script": null,
+            "min_cpu_platform": "",
+            "name": "default-20210315172233921500000001",
+            "name_prefix": "default-",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "nat_ip": "",
+                    "network_tier": "PREMIUM",
+                    "public_ptr_domain_name": ""
+                  }
+                ],
+                "alias_ip_range": [],
+                "ipv6_access_config": [],
+                "ipv6_access_type": "",
+                "name": "nic0",
+                "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
+                "network_ip": "",
+                "nic_type": "",
+                "queue_count": 0,
+                "stack_type": "",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork",
+                "subnetwork_project": "wpt-live"
+              }
+            ],
+            "project": "wpt-live",
+            "region": "us-central1",
+            "reservation_affinity": [],
+            "scheduling": [
+              {
+                "automatic_restart": true,
+                "min_node_cpus": 0,
+                "node_affinities": [],
+                "on_host_maintenance": "MIGRATE",
+                "preemptible": false,
+                "provisioning_model": ""
+              }
+            ],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001",
+            "service_account": [
+              {
+                "email": "default",
+                "scopes": [
+                  "https://www.googleapis.com/auth/cloud-platform"
+                ]
+              }
+            ],
+            "shielded_instance_config": [],
+            "tags": [
+              "allow-ssh",
+              "wpt-tot-allow"
+            ],
+            "tags_fingerprint": "",
+            "timeouts": {
+              "create": null,
+              "delete": null
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "google_compute_network.default",
+            "google_compute_subnetwork.default",
+            "module.cert-renewer-image.data.external.image",
+            "module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_instance_template",
+      "name": "wpt_server",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "advanced_machine_features": [],
+            "can_ip_forward": false,
+            "confidential_instance_config": [],
+            "description": "",
+            "disk": [
+              {
+                "auto_delete": true,
+                "boot": true,
+                "device_name": "persistent-disk-0",
+                "disk_encryption_key": [],
+                "disk_name": "",
+                "disk_size_gb": 0,
+                "disk_type": "pd-ssd",
+                "interface": "SCSI",
+                "labels": {},
+                "mode": "READ_WRITE",
+                "resource_policies": [],
+                "source": "",
+                "source_image": "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17",
+                "type": "PERSISTENT"
+              }
+            ],
+            "guest_accelerator": [],
+            "id": "default-20210315172234903400000002",
+            "instance_description": "",
+            "labels": {
+              "container-vm": "cos-stable-85-13310-1209-17"
+            },
+            "machine_type": "e2-medium",
+            "metadata": {
+              "gce-container-declaration": "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\n  restartPolicy: Always\n  volumes: []\n",
+              "google-logging-enabled": "true",
+              "startup-script": "",
+              "tf_depends_id": ""
+            },
+            "metadata_fingerprint": "g4OlLs3l5Rc=",
+            "metadata_startup_script": null,
+            "min_cpu_platform": "",
+            "name": "default-20210315172234903400000002",
+            "name_prefix": "default-",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "nat_ip": "",
+                    "network_tier": "PREMIUM",
+                    "public_ptr_domain_name": ""
+                  }
+                ],
+                "alias_ip_range": [],
+                "ipv6_access_config": [],
+                "ipv6_access_type": "",
+                "name": "nic0",
+                "network": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network",
+                "network_ip": "",
+                "nic_type": "",
+                "queue_count": 0,
+                "stack_type": "",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork",
+                "subnetwork_project": "wpt-live"
+              }
+            ],
+            "project": "wpt-live",
+            "region": "us-central1",
+            "reservation_affinity": [],
+            "scheduling": [
+              {
+                "automatic_restart": true,
+                "min_node_cpus": 0,
+                "node_affinities": [],
+                "on_host_maintenance": "MIGRATE",
+                "preemptible": false,
+                "provisioning_model": ""
+              }
+            ],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002",
+            "service_account": [
+              {
+                "email": "default",
+                "scopes": [
+                  "https://www.googleapis.com/auth/devstorage.read_only",
+                  "https://www.googleapis.com/auth/logging.write"
+                ]
+              }
+            ],
+            "shielded_instance_config": [],
+            "tags": [
+              "allow-ssh",
+              "wpt-tot-allow"
+            ],
+            "tags_fingerprint": "",
+            "timeouts": {
+              "create": null,
+              "delete": null
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "google_compute_network.default",
+            "google_compute_subnetwork.default",
+            "module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos",
+            "module.wpt-server-tot-image.data.external.image"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_compute_target_pool",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backup_pool": "",
+            "description": "",
+            "failover_ratio": 0,
+            "health_checks": [
+              "https://www.googleapis.com/compute/v1/projects/wpt-live/global/httpHealthChecks/wpt-tot-load-balancing-health-check"
+            ],
+            "id": "wpt-tot-load-balancing",
+            "instances": [
+              "us-central1-b/wpt-tot-wpt-servers-56g3",
+              "us-central1-b/wpt-tot-wpt-servers-kgdh"
+            ],
+            "name": "wpt-tot-load-balancing",
+            "project": "wpt-live",
+            "region": "us-central1",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing",
+            "session_affinity": "CLIENT_IP_PROTO",
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.wpt-live.google_compute_http_health_check.default"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_dns_record_set",
+      "name": "alt_host_bare",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "not-wpt-live/not-wpt.live./A",
+            "managed_zone": "not-wpt-live",
+            "name": "not-wpt.live.",
+            "project": "wpt-live",
+            "routing_policy": [],
+            "rrdatas": [
+              "35.223.122.27"
+            ],
+            "ttl": 300,
+            "type": "A"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.wpt-live.data.google_dns_managed_zone.alt_host",
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_dns_record_set",
+      "name": "alt_host_nonexistent_subdomains",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "not-wpt-live/nonexistent.not-wpt.live./A",
+            "managed_zone": "not-wpt-live",
+            "name": "nonexistent.not-wpt.live.",
+            "project": "wpt-live",
+            "routing_policy": [],
+            "rrdatas": [
+              "0.0.0.0"
+            ],
+            "ttl": 300,
+            "type": "A"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.wpt-live.data.google_dns_managed_zone.alt_host"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_dns_record_set",
+      "name": "alt_host_subdomains",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "not-wpt-live/*.not-wpt.live./CNAME",
+            "managed_zone": "not-wpt-live",
+            "name": "*.not-wpt.live.",
+            "project": "wpt-live",
+            "routing_policy": [],
+            "rrdatas": [
+              "not-wpt.live."
+            ],
+            "ttl": 300,
+            "type": "CNAME"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.wpt-live.data.google_dns_managed_zone.alt_host"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_dns_record_set",
+      "name": "host_bare",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "wpt-live/wpt.live./A",
+            "managed_zone": "wpt-live",
+            "name": "wpt.live.",
+            "project": "wpt-live",
+            "routing_policy": [],
+            "rrdatas": [
+              "35.223.122.27"
+            ],
+            "ttl": 300,
+            "type": "A"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.wpt-live.data.google_dns_managed_zone.host",
+            "module.wpt-live.google_compute_address.web-platform-tests-live-address"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_dns_record_set",
+      "name": "host_nonexistent_subdomains",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "wpt-live/nonexistent.wpt.live./A",
+            "managed_zone": "wpt-live",
+            "name": "nonexistent.wpt.live.",
+            "project": "wpt-live",
+            "routing_policy": [],
+            "rrdatas": [
+              "0.0.0.0"
+            ],
+            "ttl": 300,
+            "type": "A"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.wpt-live.data.google_dns_managed_zone.host"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_dns_record_set",
+      "name": "host_subdomains",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "wpt-live/*.wpt.live./CNAME",
+            "managed_zone": "wpt-live",
+            "name": "*.wpt.live.",
+            "project": "wpt-live",
+            "routing_policy": [],
+            "rrdatas": [
+              "wpt.live."
+            ],
+            "ttl": 300,
+            "type": "CNAME"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.wpt-live.data.google_dns_managed_zone.host"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "certificates",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "cors": [],
+            "default_event_based_hold": false,
+            "encryption": [],
+            "force_destroy": false,
+            "id": "wpt-tot-certificates",
+            "labels": {},
+            "lifecycle_rule": [],
+            "location": "US",
+            "logging": [],
+            "name": "wpt-tot-certificates",
+            "project": "wpt-live",
+            "requester_pays": false,
+            "retention_policy": [],
+            "self_link": "https://www.googleapis.com/storage/v1/b/wpt-tot-certificates",
+            "storage_class": "STANDARD",
+            "timeouts": {
+              "create": null,
+              "read": null,
+              "update": null
+            },
+            "uniform_bucket_level_access": false,
+            "url": "gs://wpt-tot-certificates",
+            "versioning": [],
+            "website": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live.module.cert-renewer-container",
+      "mode": "data",
+      "type": "google_compute_image",
+      "name": "coreos",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "archive_size_bytes": 1302779136,
+            "creation_timestamp": "2022-07-18T12:02:35.860-07:00",
+            "description": "Google, Container-Optimized OS, 97-16919.103.16 stable, Kernel: COS-5.10.123 Kubernetes: 1.23.3 Docker: 20.10.12 Family: cos-stable, supports Shielded VM features, supports Confidential VM features on N2D",
+            "disk_size_gb": 10,
+            "family": "cos-stable",
+            "filter": null,
+            "id": "projects/cos-cloud/global/images/cos-stable-97-16919-103-16",
+            "image_encryption_key_sha256": "",
+            "image_id": "3100497367560360100",
+            "label_fingerprint": "pB95vtJSKZo=",
+            "labels": {
+              "build_number": "16919-103-16",
+              "milestone": "97"
+            },
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos",
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud-shielded/global/licenses/shielded-cos",
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos-pcid"
+            ],
+            "name": "cos-stable-97-16919-103-16",
+            "project": "cos-cloud",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-97-16919-103-16",
+            "source_disk": "",
+            "source_disk_encryption_key_sha256": "",
+            "source_disk_id": "",
+            "source_image_id": "",
+            "status": "READY"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-live.module.wpt-server-container",
+      "mode": "data",
+      "type": "google_compute_image",
+      "name": "coreos",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "archive_size_bytes": 1302779136,
+            "creation_timestamp": "2022-07-18T12:02:35.860-07:00",
+            "description": "Google, Container-Optimized OS, 97-16919.103.16 stable, Kernel: COS-5.10.123 Kubernetes: 1.23.3 Docker: 20.10.12 Family: cos-stable, supports Shielded VM features, supports Confidential VM features on N2D",
+            "disk_size_gb": 10,
+            "family": "cos-stable",
+            "filter": null,
+            "id": "projects/cos-cloud/global/images/cos-stable-97-16919-103-16",
+            "image_encryption_key_sha256": "",
+            "image_id": "3100497367560360100",
+            "label_fingerprint": "pB95vtJSKZo=",
+            "labels": {
+              "build_number": "16919-103-16",
+              "milestone": "97"
+            },
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos",
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud-shielded/global/licenses/shielded-cos",
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos-pcid"
+            ],
+            "name": "cos-stable-97-16919-103-16",
+            "project": "cos-cloud",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-97-16919-103-16",
+            "source_disk": "",
+            "source_disk_encryption_key_sha256": "",
+            "source_disk_id": "",
+            "source_image_id": "",
+            "status": "READY"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.wpt-server-tot-image",
+      "mode": "data",
+      "type": "external",
+      "name": "image",
+      "provider": "provider[\"registry.terraform.io/hashicorp/external\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "-",
+            "program": [
+              "python3",
+              "infrastructure/docker-image/latest-image.py",
+              "--registry",
+              "gcr.io",
+              "--image",
+              "wpt-live/wpt-live-wpt-server-tot"
+            ],
+            "query": null,
+            "result": {
+              "identifier": "sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe",
+              "time_created": "1610631609527"
+            },
+            "working_dir": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    }
+  ]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = "~> 1.2.5"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}


### PR DESCRIPTION
99% of the changes were done automatically and can be ignored as I performed the upgrade
across each version using commands like `terraform 0.12upgrade` and
`terraform 0.13upgrade`.

This commit was separated out because it was to make Part 1 more
re-viewable.

However manual changes needed to be done
Only manual changes done:
- Removal of the references to the null_resource. We don't use the depends_id like the removed modules in part 1 did.
- `terraform state mv` all migrated resources from [wpt-servers](https://github.com/web-platform-tests/wpt.live/blob/67dc5976ccce2e64483f2028a35659d4d6e58891/infrastructure/web-platform-tests/main.tf#L69) and [cert-renewers](https://github.com/web-platform-tests/wpt.live/blob/67dc5976ccce2e64483f2028a35659d4d6e58891/infrastructure/web-platform-tests/main.tf#L139) to the resources now in compute.tf


<details><summary>Show Plan</summary>

```
module.cert-renewer-image.data.external.image: Reading...
module.wpt-server-tot-image.data.external.image: Reading...
module.cert-renewer-image.data.external.image: Read complete after 0s [id=-]
module.wpt-server-tot-image.data.external.image: Read complete after 0s [id=-]
module.wpt-live.data.google_dns_managed_zone.alt_host: Reading...
module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos: Reading...
module.wpt-live.google_compute_address.web-platform-tests-live-address: Refreshing state... [id=wpt-live/us-central1/wpt-tot-address]
module.wpt-live.google_storage_bucket.certificates: Refreshing state... [id=wpt-tot-certificates]
google_compute_network.default: Refreshing state... [id=wpt-live-network]
module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos: Reading...
module.wpt-live.data.google_dns_managed_zone.host: Reading...
module.wpt-live.google_compute_http_health_check.default: Refreshing state... [id=wpt-tot-load-balancing-health-check]
module.wpt-live.google_compute_health_check.wpt_health_check: Refreshing state... [id=wpt-tot-wpt-servers]
module.wpt-live.data.google_dns_managed_zone.host: Read complete after 0s [id=projects/wpt-live/managedZones/wpt-live]
module.wpt-live.google_dns_record_set.host_subdomains: Refreshing state... [id=wpt-live/*.wpt.live./CNAME]
module.wpt-live.data.google_dns_managed_zone.alt_host: Read complete after 0s [id=projects/wpt-live/managedZones/not-wpt-live]
module.wpt-live.google_dns_record_set.host_nonexistent_subdomains: Refreshing state... [id=wpt-live/nonexistent.wpt.live./A]
module.wpt-live.google_dns_record_set.alt_host_nonexistent_subdomains: Refreshing state... [id=not-wpt-live/nonexistent.not-wpt.live./A]
module.wpt-live.google_dns_record_set.alt_host_subdomains: Refreshing state... [id=not-wpt-live/*.not-wpt.live./CNAME]
module.wpt-live.google_dns_record_set.alt_host_bare: Refreshing state... [id=not-wpt-live/not-wpt.live./A]
module.wpt-live.google_dns_record_set.host_bare: Refreshing state... [id=wpt-live/wpt.live./A]
module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos: Read complete after 0s [id=projects/cos-cloud/global/images/cos-stable-85-13310-1209-17]
google_compute_subnetwork.default: Refreshing state... [id=us-central1/wpt-live-subnetwork]
module.wpt-live.google_compute_firewall.wpt-servers-default-ssh: Refreshing state... [id=wpt-tot-wpt-servers-vm-ssh]
module.wpt-live.google_compute_firewall.wpt-server-mig-health-check: Refreshing state... [id=wpt-tot-wpt-servers-vm-hc]
module.wpt-live.google_compute_firewall.default-lb-fw: Refreshing state... [id=wpt-tot-load-balancing-vm-service]
module.wpt-live.google_compute_target_pool.default: Refreshing state... [id=wpt-tot-load-balancing]
module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos: Read complete after 0s [id=projects/cos-cloud/global/images/cos-stable-85-13310-1209-17]
module.wpt-live.google_compute_instance_template.cert_renewers: Refreshing state... [id=default-20210315172233921500000001]
module.wpt-live.google_compute_instance_template.wpt_server: Refreshing state... [id=default-20210315172234903400000002]
module.wpt-live.google_compute_forwarding_rule.default[3]: Refreshing state... [id=wpt-tot-load-balancing-3]
module.wpt-live.google_compute_forwarding_rule.default[4]: Refreshing state... [id=wpt-tot-load-balancing-4]
module.wpt-live.google_compute_forwarding_rule.default[1]: Refreshing state... [id=wpt-tot-load-balancing-1]
module.wpt-live.google_compute_forwarding_rule.default[0]: Refreshing state... [id=wpt-tot-load-balancing-0]
module.wpt-live.google_compute_forwarding_rule.default[5]: Refreshing state... [id=wpt-tot-load-balancing-5]
module.wpt-live.google_compute_forwarding_rule.default[2]: Refreshing state... [id=wpt-tot-load-balancing-2]
module.wpt-live.google_compute_forwarding_rule.default[6]: Refreshing state... [id=wpt-tot-load-balancing-6]
module.wpt-live.google_compute_instance_group_manager.cert_renewers: Refreshing state... [id=wpt-live/us-central1-b/wpt-tot-cert-renewers]
module.wpt-live.google_compute_instance_group_manager.wpt_servers: Refreshing state... [id=wpt-live/us-central1-b/wpt-tot-wpt-servers]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

```

</details>

More details: #61 