### PR TITLE
[Part 3/3] Use latest OS image and use new metadata format

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,6 @@ Cloud Platform with the state described by the configuration files in this
 repository:
 
     terraform apply
+
+Create a separate PR with the changes to the terraform.tfstate file after the
+deployment is successful.

--- a/infrastructure/web-platform-tests/compute.tf
+++ b/infrastructure/web-platform-tests/compute.tf
@@ -230,9 +230,7 @@ resource "google_compute_instance_group_manager" "cert_renewers" {
   zone = var.zone
 
   update_policy {
-    # The type is different from wpt servers's update policy.
-    # TODO: Evaluate why
-    type                  = "OPPORTUNISTIC"
+    type                  = local.update_policy.type
     minimal_action        = local.update_policy.minimal_action
     max_unavailable_fixed = local.update_policy.max_unavailable_fixed
   }

--- a/infrastructure/web-platform-tests/compute.tf
+++ b/infrastructure/web-platform-tests/compute.tf
@@ -141,27 +141,7 @@ resource "google_compute_instance_template" "wpt_server" {
   # startup-script and tf_depends_id comes from the module previously used for wpt-server. (see link at top)
   # TODO: evaluate if those two should be removed.
   metadata = {
-    # "${module.wpt-server-container.metadata_key}" = module.wpt-server-container.metadata_value
-    # The value for ${module.wpt-server-container.metadata_key} is temporary. During the upgrade, the metadata rendering changes.
-    # More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/master/docs/upgrading_to_v2.0.md
-    # Clarification to the linked docs, metadata changes will destroy the old template and create a new one.
-    # In order to make this as smooth as possible, we will hardcode this.
-    # When ready, remove this temporary metadata and the one on cert-renewer. And uncomment the line above.
-    "${module.wpt-server-container.metadata_key}" = <<-EOT
-              ---
-              spec:
-                containers:
-                - env:
-                  - name: WPT_HOST
-                    value: wpt.live
-                  - name: WPT_ALT_HOST
-                    value: not-wpt.live
-                  - name: WPT_BUCKET
-                    value: wpt-tot-certificates
-                  image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe
-                restartPolicy: Always
-                volumes: []
-              EOT
+    "${module.wpt-server-container.metadata_key}" = module.wpt-server-container.metadata_value
     "startup-script"                              = ""
     "tf_depends_id"                               = ""
     "google-logging-enabled"                      = "true"
@@ -219,27 +199,7 @@ resource "google_compute_instance_template" "cert_renewers" {
   # startup-script and tf_depends_id comes from the module previously used for cert renewer. (see link at top)
   # TODO: evaluate if those two should be removed.
   metadata = {
-    # "${module.cert-renewer-container.metadata_key}" = module.cert-renewer-container.metadata_value
-    # The value for ${module.cert-renewer-container.metadata_key} is temporary. During the upgrade, the metadata rendering changes.
-    # More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/master/docs/upgrading_to_v2.0.md
-    # Clarification to the linked docs, metadata changes will destroy the old template and create a new one.
-    # In order to make this as smooth as possible, we will hardcode this.
-    # When ready, remove this temporary metadata and the one on wpt-server. And uncomment the line above.
-    "${module.cert-renewer-container.metadata_key}" = <<-EOT
-              ---
-              spec:
-                containers:
-                - env:
-                  - name: WPT_HOST
-                    value: wpt.live
-                  - name: WPT_ALT_HOST
-                    value: not-wpt.live
-                  - name: WPT_BUCKET
-                    value: wpt-tot-certificates
-                  image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5
-                restartPolicy: Always
-                volumes: []
-              EOT
+    "${module.cert-renewer-container.metadata_key}" = module.cert-renewer-container.metadata_value
     "startup-script"                                = ""
     "tf_depends_id"                                 = ""
     "google-logging-enabled"                        = "true"

--- a/infrastructure/web-platform-tests/main.tf
+++ b/infrastructure/web-platform-tests/main.tf
@@ -15,8 +15,6 @@ module "wpt-server-container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "3.0.0"
 
-  # Temporary variable
-  cos_image_name = var.cos_image_name
   container = {
     image = var.wpt_server_image
     env = [
@@ -42,8 +40,6 @@ module "cert-renewer-container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "3.0.0"
 
-  # Temporary variable
-  cos_image_name = var.cos_image_name
   container = {
     image = var.cert_renewer_image
     env = [

--- a/infrastructure/web-platform-tests/variables.tf
+++ b/infrastructure/web-platform-tests/variables.tf
@@ -103,9 +103,3 @@ variable "cert_renewer_ports" {
     }
   ]
 }
-
-variable "cos_image_name" {
-  description = "Name of specific COS image. Temporary variable. Will remove here and in main.tf once ready to upgrade. More info: https://github.com/terraform-google-modules/terraform-google-container-vm/blob/5e69eafaaaa8302c5732799e32d1da5c17b7b285/variables.tf#L46"
-  type        = string
-  default     = "cos-stable-85-13310-1209-17"
-}


### PR DESCRIPTION
- Removes the hardcoded OS image so that terraform will build a template
  with the latest os image
- Previously, the metadata was hardcoded to ensure there were no diffs
  upon upgrading to the latest version of terraform. This change now
uses the new format for metadata for containers. (Which would have
caused a diff in part 1)

---

# Comparison of terraform plan between 0.11.4 and 1.2.5

<details><summary>Show 0.11.4 Plan</summary>

```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.external.image: Refreshing state...
data.external.image: Refreshing state...
google_compute_network.default: Refreshing state... (ID: wpt-live-network)
google_storage_bucket.certificates: Refreshing state... (ID: wpt-tot-certificates)
google_compute_address.web-platform-tests-live-address: Refreshing state... (ID: wpt-live/us-central1/wpt-tot-address)
google_compute_http_health_check.default: Refreshing state... (ID: wpt-tot-load-balancing-health-check)
data.google_dns_managed_zone.alt_host: Refreshing state...
data.google_compute_image.coreos: Refreshing state...
data.google_compute_zones.available: Refreshing state...
data.google_compute_image.coreos: Refreshing state...
data.google_dns_managed_zone.host: Refreshing state...
google_compute_health_check.mig-health-check: Refreshing state... (ID: wpt-tot-wpt-servers)
data.google_compute_zones.available: Refreshing state...
google_dns_record_set.alt_host_subdomains: Refreshing state... (ID: not-wpt-live/*.not-wpt.live./CNAME)
google_dns_record_set.alt_host_bare: Refreshing state... (ID: not-wpt-live/not-wpt.live./A)
google_dns_record_set.alt_host_nonexistent_subdomains: Refreshing state... (ID: not-wpt-live/nonexistent.not-wpt.live./A)
google_dns_record_set.host_nonexistent_subdomains: Refreshing state... (ID: wpt-live/nonexistent.wpt.live./A)
google_dns_record_set.host_bare: Refreshing state... (ID: wpt-live/wpt.live./A)
google_compute_subnetwork.default: Refreshing state... (ID: us-central1/wpt-live-subnetwork)
google_dns_record_set.host_subdomains: Refreshing state... (ID: wpt-live/*.wpt.live./CNAME)
google_compute_firewall.default-lb-fw: Refreshing state... (ID: wpt-tot-load-balancing-vm-service)
google_compute_firewall.mig-health-check: Refreshing state... (ID: wpt-tot-wpt-servers-vm-hc)
google_compute_firewall.default-ssh: Refreshing state... (ID: wpt-tot-wpt-servers-vm-ssh)
google_compute_target_pool.default: Refreshing state... (ID: wpt-tot-load-balancing)
data.external.spec_as_yaml: Refreshing state...
data.external.spec_as_yaml: Refreshing state...
google_compute_forwarding_rule.default[0]: Refreshing state... (ID: wpt-tot-load-balancing-0)
google_compute_forwarding_rule.default[1]: Refreshing state... (ID: wpt-tot-load-balancing-1)
google_compute_forwarding_rule.default[2]: Refreshing state... (ID: wpt-tot-load-balancing-2)
google_compute_forwarding_rule.default[3]: Refreshing state... (ID: wpt-tot-load-balancing-3)
google_compute_forwarding_rule.default[4]: Refreshing state... (ID: wpt-tot-load-balancing-4)
google_compute_forwarding_rule.default[5]: Refreshing state... (ID: wpt-tot-load-balancing-5)
google_compute_instance_template.default: Refreshing state... (ID: default-20210315172233921500000001)
google_compute_instance_template.default: Refreshing state... (ID: default-20210315172234903400000002)
google_compute_instance_group_manager.default: Refreshing state... (ID: wpt-live/us-central1-b/wpt-tot-cert-renewers)
google_compute_instance_group_manager.default: Refreshing state... (ID: wpt-live/us-central1-b/wpt-tot-wpt-servers)
null_resource.dummy_dependency: Refreshing state... (ID: 929056379834909265)
null_resource.dummy_dependency: Refreshing state... (ID: 974901135113459607)
data.google_compute_instance_group.zonal: Refreshing state...
data.google_compute_instance_group.zonal: Refreshing state...

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

+ module.wpt-live.google_compute_forwarding_rule.default[6]
      id:                                                         <computed>
      creation_timestamp:                                         <computed>
      ip_address:                                                 "35.223.122.27"
      load_balancing_scheme:                                      "EXTERNAL"
      name:                                                       "wpt-tot-load-balancing-6"
      network_tier:                                               <computed>
      port_range:                                                 "8443"
      project:                                                    <computed>
      self_link:                                                  <computed>
      service_name:                                               <computed>
      target:                                                     "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/targetPools/wpt-tot-load-balancing"

  ~ module.wpt-live.module.cert-renewers.google_compute_instance_group_manager.default
      auto_healing_policies.#:                                    "0" => "1"
      auto_healing_policies.0.initial_delay_sec:                  "" => "30"
      update_policy.0.type:                                       "OPPORTUNISTIC" => "PROACTIVE"
      version.0.instance_template:                                "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001" => "${google_compute_instance_template.default.self_link}"
      version.0.name:                                             "" => "wpt-tot-cert-renewers-default"

-/+ module.wpt-live.module.cert-renewers.google_compute_instance_template.default (new resource required)
      id:                                                         "default-20210315172233921500000001" => <computed> (forces new resource)
      can_ip_forward:                                             "false" => "false"
      disk.#:                                                     "1" => "1"
      disk.0.auto_delete:                                         "true" => "true"
      disk.0.boot:                                                "true" => "true"
      disk.0.device_name:                                         "persistent-disk-0" => <computed>
      disk.0.disk_size_gb:                                        "0" => "0"
      disk.0.disk_type:                                           "pd-ssd" => "pd-ssd"
      disk.0.interface:                                           "SCSI" => <computed>
      disk.0.mode:                                                "READ_WRITE" => "READ_WRITE"
      disk.0.source_image:                                        "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17" => "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-97-16919-103-16" (forces new resource)
      disk.0.type:                                                "PERSISTENT" => "PERSISTENT"
      labels.%:                                                   "1" => "1"
      labels.container-vm:                                        "cos-stable-85-13310-1209-17" => "cos-stable-97-16919-103-16" (forces new resource)
      machine_type:                                               "f1-micro" => "f1-micro"
      metadata.%:                                                 "4" => "4"
      metadata.gce-container-declaration:                         "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\n  restartPolicy: Always\n  volumes: []\n" => "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\n  restartPolicy: Always\n  volumes: []\n"
      metadata.google-logging-enabled:                            "true" => "true"
      metadata.startup-script:                                    "" => ""
      metadata.tf_depends_id:                                     "" => ""
      metadata_fingerprint:                                       "J6IpzJ9_WzA=" => <computed>
      name:                                                       "default-20210315172233921500000001" => <computed>
      name_prefix:                                                "default-" => "default-"
      network_interface.#:                                        "1" => "1"
      network_interface.0.access_config.#:                        "1" => "1"
      network_interface.0.access_config.0.assigned_nat_ip:        "" => <computed>
      network_interface.0.access_config.0.nat_ip:                 "" => <computed>
      network_interface.0.access_config.0.network_tier:           "PREMIUM" => <computed>
      network_interface.0.access_config.0.public_ptr_domain_name: "" => <computed>
      network_interface.0.address:                                "" => <computed>
      network_interface.0.name:                                   "nic0" => <computed>
      network_interface.0.subnetwork:                             "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork" => "wpt-live-subnetwork"
      network_interface.0.subnetwork_project:                     "wpt-live" => <computed>
      project:                                                    "wpt-live" => <computed>
      region:                                                     "us-central1" => "us-central1"
      scheduling.#:                                               "1" => "1"
      scheduling.0.automatic_restart:                             "true" => "true"
      scheduling.0.on_host_maintenance:                           "MIGRATE" => <computed>
      scheduling.0.preemptible:                                   "false" => "false"
      self_link:                                                  "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001" => <computed>
      service_account.#:                                          "1" => "1"
      service_account.0.email:                                    "default" => "default"
      service_account.0.scopes.#:                                 "1" => "1"
      service_account.0.scopes.1733087937:                        "https://www.googleapis.com/auth/cloud-platform" => "https://www.googleapis.com/auth/cloud-platform"
      tags.#:                                                     "2" => "2"
      tags.2542268873:                                            "allow-ssh" => "allow-ssh"
      tags.2803589456:                                            "wpt-tot-allow" => "wpt-tot-allow"
      tags_fingerprint:                                           "" => <computed>

-/+ module.wpt-live.module.cert-renewers.null_resource.dummy_dependency (new resource required)
      id:                                                         "929056379834909265" => <computed> (forces new resource)
      triggers.%:                                                 "1" => <computed> (forces new resource)
      triggers.instance_template:                                 "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001" => "" (forces new resource)

  ~ module.wpt-live.module.wpt-servers.google_compute_instance_group_manager.default
      version.0.instance_template:                                "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002" => "${google_compute_instance_template.default.self_link}"

-/+ module.wpt-live.module.wpt-servers.google_compute_instance_template.default (new resource required)
      id:                                                         "default-20210315172234903400000002" => <computed> (forces new resource)
      can_ip_forward:                                             "false" => "false"
      disk.#:                                                     "1" => "1"
      disk.0.auto_delete:                                         "true" => "true"
      disk.0.boot:                                                "true" => "true"
      disk.0.device_name:                                         "persistent-disk-0" => <computed>
      disk.0.disk_size_gb:                                        "0" => "0"
      disk.0.disk_type:                                           "pd-ssd" => "pd-ssd"
      disk.0.interface:                                           "SCSI" => <computed>
      disk.0.mode:                                                "READ_WRITE" => "READ_WRITE"
      disk.0.source_image:                                        "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17" => "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-97-16919-103-16" (forces new resource)
      disk.0.type:                                                "PERSISTENT" => "PERSISTENT"
      labels.%:                                                   "1" => "1"
      labels.container-vm:                                        "cos-stable-85-13310-1209-17" => "cos-stable-97-16919-103-16" (forces new resource)
      machine_type:                                               "e2-medium" => "e2-medium"
      metadata.%:                                                 "4" => "4"
      metadata.gce-container-declaration:                         "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\n  restartPolicy: Always\n  volumes: []\n" => "---\nspec:\n  containers:\n  - env:\n    - name: WPT_HOST\n      value: wpt.live\n    - name: WPT_ALT_HOST\n      value: not-wpt.live\n    - name: WPT_BUCKET\n      value: wpt-tot-certificates\n    image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\n  restartPolicy: Always\n  volumes: []\n"
      metadata.google-logging-enabled:                            "true" => "true"
      metadata.startup-script:                                    "" => ""
      metadata.tf_depends_id:                                     "" => ""
      metadata_fingerprint:                                       "g4OlLs3l5Rc=" => <computed>
      name:                                                       "default-20210315172234903400000002" => <computed>
      name_prefix:                                                "default-" => "default-"
      network_interface.#:                                        "1" => "1"
      network_interface.0.access_config.#:                        "1" => "1"
      network_interface.0.access_config.0.assigned_nat_ip:        "" => <computed>
      network_interface.0.access_config.0.nat_ip:                 "" => <computed>
      network_interface.0.access_config.0.network_tier:           "PREMIUM" => <computed>
      network_interface.0.access_config.0.public_ptr_domain_name: "" => <computed>
      network_interface.0.address:                                "" => <computed>
      network_interface.0.name:                                   "nic0" => <computed>
      network_interface.0.subnetwork:                             "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork" => "wpt-live-subnetwork"
      network_interface.0.subnetwork_project:                     "wpt-live" => <computed>
      project:                                                    "wpt-live" => <computed>
      region:                                                     "us-central1" => "us-central1"
      scheduling.#:                                               "1" => "1"
      scheduling.0.automatic_restart:                             "true" => "true"
      scheduling.0.on_host_maintenance:                           "MIGRATE" => <computed>
      scheduling.0.preemptible:                                   "false" => "false"
      self_link:                                                  "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002" => <computed>
      service_account.#:                                          "1" => "1"
      service_account.0.email:                                    "default" => "default"
      service_account.0.scopes.#:                                 "2" => "2"
      service_account.0.scopes.1632638332:                        "https://www.googleapis.com/auth/devstorage.read_only" => "https://www.googleapis.com/auth/devstorage.read_only"
      service_account.0.scopes.172152165:                         "https://www.googleapis.com/auth/logging.write" => "https://www.googleapis.com/auth/logging.write"
      tags.#:                                                     "2" => "2"
      tags.2542268873:                                            "allow-ssh" => "allow-ssh"
      tags.2803589456:                                            "wpt-tot-allow" => "wpt-tot-allow"
      tags_fingerprint:                                           "" => <computed>

-/+ module.wpt-live.module.wpt-servers.null_resource.dummy_dependency (new resource required)
      id:                                                         "974901135113459607" => <computed> (forces new resource)
      triggers.%:                                                 "1" => <computed> (forces new resource)
      triggers.instance_template:                                 "https://www.googleapis.com/compute/beta/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002" => "" (forces new resource)
Plan: 5 to add, 2 to change, 4 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```

</details>


<details><summary>Show 1.2.5 Plan</summary>

```
module.cert-renewer-image.data.external.image: Reading...
module.wpt-server-tot-image.data.external.image: Reading...
google_compute_network.default: Refreshing state... [id=wpt-live-network]
module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos: Reading...
module.wpt-live.data.google_dns_managed_zone.alt_host: Reading...
module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos: Reading...
module.wpt-live.google_compute_address.web-platform-tests-live-address: Refreshing state... [id=wpt-live/us-central1/wpt-tot-address]
module.wpt-live.google_storage_bucket.certificates: Refreshing state... [id=wpt-tot-certificates]
module.wpt-live.google_compute_http_health_check.default: Refreshing state... [id=wpt-tot-load-balancing-health-check]
module.wpt-live.google_compute_health_check.wpt_health_check: Refreshing state... [id=wpt-tot-wpt-servers]
module.wpt-server-tot-image.data.external.image: Read complete after 0s [id=-]
module.wpt-live.data.google_dns_managed_zone.host: Reading...
module.cert-renewer-image.data.external.image: Read complete after 0s [id=-]
module.wpt-live.data.google_dns_managed_zone.alt_host: Read complete after 1s [id=projects/wpt-live/managedZones/not-wpt-live]
module.wpt-live.data.google_dns_managed_zone.host: Read complete after 1s [id=projects/wpt-live/managedZones/wpt-live]
module.wpt-live.google_dns_record_set.alt_host_nonexistent_subdomains: Refreshing state... [id=not-wpt-live/nonexistent.not-wpt.live./A]
module.wpt-live.google_dns_record_set.host_nonexistent_subdomains: Refreshing state... [id=wpt-live/nonexistent.wpt.live./A]
module.wpt-live.google_dns_record_set.host_subdomains: Refreshing state... [id=wpt-live/*.wpt.live./CNAME]
module.wpt-live.google_dns_record_set.alt_host_subdomains: Refreshing state... [id=not-wpt-live/*.not-wpt.live./CNAME]
google_compute_subnetwork.default: Refreshing state... [id=us-central1/wpt-live-subnetwork]
module.wpt-live.google_compute_firewall.wpt-servers-default-ssh: Refreshing state... [id=wpt-tot-wpt-servers-vm-ssh]
module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos: Read complete after 1s [id=projects/cos-cloud/global/images/cos-stable-97-16919-103-16]
module.wpt-live.google_compute_firewall.default-lb-fw: Refreshing state... [id=wpt-tot-load-balancing-vm-service]
module.wpt-live.google_compute_firewall.wpt-server-mig-health-check: Refreshing state... [id=wpt-tot-wpt-servers-vm-hc]
module.wpt-live.google_dns_record_set.host_bare: Refreshing state... [id=wpt-live/wpt.live./A]
module.wpt-live.google_dns_record_set.alt_host_bare: Refreshing state... [id=not-wpt-live/not-wpt.live./A]
module.wpt-live.google_compute_target_pool.default: Refreshing state... [id=wpt-tot-load-balancing]
module.wpt-live.google_compute_instance_template.wpt_server: Refreshing state... [id=default-20210315172234903400000002]
module.wpt-live.module.cert-renewer-container.data.google_compute_image.coreos: Read complete after 1s [id=projects/cos-cloud/global/images/cos-stable-97-16919-103-16]
module.wpt-live.google_compute_instance_template.cert_renewers: Refreshing state... [id=default-20210315172233921500000001]
module.wpt-live.google_compute_forwarding_rule.default[3]: Refreshing state... [id=wpt-tot-load-balancing-3]
module.wpt-live.google_compute_forwarding_rule.default[0]: Refreshing state... [id=wpt-tot-load-balancing-0]
module.wpt-live.google_compute_forwarding_rule.default[6]: Refreshing state... [id=wpt-tot-load-balancing-6]
module.wpt-live.google_compute_forwarding_rule.default[1]: Refreshing state... [id=wpt-tot-load-balancing-1]
module.wpt-live.google_compute_forwarding_rule.default[4]: Refreshing state... [id=wpt-tot-load-balancing-4]
module.wpt-live.google_compute_forwarding_rule.default[2]: Refreshing state... [id=wpt-tot-load-balancing-2]
module.wpt-live.google_compute_forwarding_rule.default[5]: Refreshing state... [id=wpt-tot-load-balancing-5]
module.wpt-live.google_compute_instance_group_manager.wpt_servers: Refreshing state... [id=wpt-live/us-central1-b/wpt-tot-wpt-servers]
module.wpt-live.google_compute_instance_group_manager.cert_renewers: Refreshing state... [id=wpt-live/us-central1-b/wpt-tot-cert-renewers]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place
+/- create replacement and then destroy

Terraform will perform the following actions:

  # module.wpt-live.google_compute_instance_group_manager.cert_renewers will be updated in-place
  ~ resource "google_compute_instance_group_manager" "cert_renewers" {
        id                        = "wpt-live/us-central1-b/wpt-tot-cert-renewers"
        name                      = "wpt-tot-cert-renewers"
        # (12 unchanged attributes hidden)

      ~ version {
          ~ instance_template = "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001" -> (known after apply)
        }

        # (3 unchanged blocks hidden)
    }

  # module.wpt-live.google_compute_instance_group_manager.wpt_servers will be updated in-place
  ~ resource "google_compute_instance_group_manager" "wpt_servers" {
        id                        = "wpt-live/us-central1-b/wpt-tot-wpt-servers"
        name                      = "wpt-tot-wpt-servers"
        # (12 unchanged attributes hidden)

      ~ version {
          ~ instance_template = "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002" -> (known after apply)
            name              = "wpt-tot-wpt-servers-default"
        }

        # (10 unchanged blocks hidden)
    }

  # module.wpt-live.google_compute_instance_template.cert_renewers must be replaced
+/- resource "google_compute_instance_template" "cert_renewers" {
      ~ id                   = "default-20210315172233921500000001" -> (known after apply)
      ~ labels               = { # forces replacement
          ~ "container-vm" = "cos-stable-85-13310-1209-17" -> "cos-stable-97-16919-103-16"
        }
      ~ metadata             = { # forces replacement
          ~ "gce-container-declaration" = <<-EOT
              - ---
              - spec:
              -   containers:
              -   - env:
              -     - name: WPT_HOST
              -       value: wpt.live
              -     - name: WPT_ALT_HOST
              -       value: not-wpt.live
              -     - name: WPT_BUCKET
              -       value: wpt-tot-certificates
              -     image: gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5
              -   restartPolicy: Always
              -   volumes: []
              + "spec":
              +   "containers":
              +   - "env":
              +     - "name": "WPT_HOST"
              +       "value": "wpt.live"
              +     - "name": "WPT_ALT_HOST"
              +       "value": "not-wpt.live"
              +     - "name": "WPT_BUCKET"
              +       "value": "wpt-tot-certificates"
              +     "image": "gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5"
              +   "restartPolicy": "Always"
              +   "volumes": []
            EOT
            # (3 unchanged elements hidden)
        }
      ~ metadata_fingerprint = "J6IpzJ9_WzA=" -> (known after apply)
      ~ name                 = "default-20210315172233921500000001" -> (known after apply)
      ~ project              = "wpt-live" -> (known after apply)
      ~ self_link            = "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172233921500000001" -> (known after apply)
        tags                 = [
            "allow-ssh",
            "wpt-tot-allow",
        ]
      + tags_fingerprint     = (known after apply)
        # (4 unchanged attributes hidden)

      + confidential_instance_config {
          + enable_confidential_compute = (known after apply)
        }

      ~ disk {
          ~ device_name       = "persistent-disk-0" -> (known after apply)
          ~ disk_size_gb      = 0 -> (known after apply)
          ~ interface         = "SCSI" -> (known after apply)
          - labels            = {} -> null
          - resource_policies = [] -> null
          ~ source_image      = "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17" -> "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-97-16919-103-16" # forces replacement
            # (5 unchanged attributes hidden)
        }

      ~ network_interface {
          + ipv6_access_type   = (known after apply)
          ~ name               = "nic0" -> (known after apply)
          ~ network            = "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network" -> "wpt-live-network"
          - queue_count        = 0 -> null
          + stack_type         = (known after apply)
          ~ subnetwork         = "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork" -> "wpt-live-subnetwork"
          ~ subnetwork_project = "wpt-live" -> (known after apply)

          ~ access_config {
              + nat_ip                 = (known after apply)
              + public_ptr_domain_name = (known after apply)
                # (1 unchanged attribute hidden)
            }
        }

      ~ scheduling {
          - min_node_cpus       = 0 -> null
          + provisioning_model  = (known after apply)
            # (3 unchanged attributes hidden)
        }

      - timeouts {}

        # (1 unchanged block hidden)
    }

  # module.wpt-live.google_compute_instance_template.wpt_server must be replaced
+/- resource "google_compute_instance_template" "wpt_server" {
      ~ id                   = "default-20210315172234903400000002" -> (known after apply)
      ~ labels               = { # forces replacement
          ~ "container-vm" = "cos-stable-85-13310-1209-17" -> "cos-stable-97-16919-103-16"
        }
      ~ metadata             = { # forces replacement
          ~ "gce-container-declaration" = <<-EOT
              - ---
              - spec:
              -   containers:
              -   - env:
              -     - name: WPT_HOST
              -       value: wpt.live
              -     - name: WPT_ALT_HOST
              -       value: not-wpt.live
              -     - name: WPT_BUCKET
              -       value: wpt-tot-certificates
              -     image: gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe
              -   restartPolicy: Always
              -   volumes: []
              + "spec":
              +   "containers":
              +   - "env":
              +     - "name": "WPT_HOST"
              +       "value": "wpt.live"
              +     - "name": "WPT_ALT_HOST"
              +       "value": "not-wpt.live"
              +     - "name": "WPT_BUCKET"
              +       "value": "wpt-tot-certificates"
              +     "image": "gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe"
              +   "restartPolicy": "Always"
              +   "volumes": []
            EOT
            # (3 unchanged elements hidden)
        }
      ~ metadata_fingerprint = "g4OlLs3l5Rc=" -> (known after apply)
      ~ name                 = "default-20210315172234903400000002" -> (known after apply)
      ~ project              = "wpt-live" -> (known after apply)
      ~ region               = "us-central1" -> (known after apply)
      ~ self_link            = "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20210315172234903400000002" -> (known after apply)
        tags                 = [
            "allow-ssh",
            "wpt-tot-allow",
        ]
      + tags_fingerprint     = (known after apply)
        # (3 unchanged attributes hidden)

      + confidential_instance_config {
          + enable_confidential_compute = (known after apply)
        }

      ~ disk {
          ~ device_name       = "persistent-disk-0" -> (known after apply)
          ~ interface         = "SCSI" -> (known after apply)
          - labels            = {} -> null
          - resource_policies = [] -> null
          ~ source_image      = "projects/cos-cloud/global/images/cos-stable-85-13310-1209-17" -> "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-97-16919-103-16" # forces replacement
            # (6 unchanged attributes hidden)
        }

      ~ network_interface {
          + ipv6_access_type   = (known after apply)
          ~ name               = "nic0" -> (known after apply)
          ~ network            = "https://www.googleapis.com/compute/v1/projects/wpt-live/global/networks/wpt-live-network" -> "wpt-live-network"
          - queue_count        = 0 -> null
          + stack_type         = (known after apply)
          ~ subnetwork         = "https://www.googleapis.com/compute/v1/projects/wpt-live/regions/us-central1/subnetworks/wpt-live-subnetwork" -> "wpt-live-subnetwork"
          ~ subnetwork_project = "wpt-live" -> (known after apply)

          ~ access_config {
              + nat_ip                 = (known after apply)
              + public_ptr_domain_name = (known after apply)
                # (1 unchanged attribute hidden)
            }
        }

      ~ scheduling {
          - min_node_cpus       = 0 -> null
          + provisioning_model  = (known after apply)
            # (3 unchanged attributes hidden)
        }

      - timeouts {}

        # (1 unchanged block hidden)
    }

Plan: 2 to add, 2 to change, 2 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
```


</details>


You'll note that with the changes made in #58 and #59 , we do not have the null_resource because they were never used.

Closes #62