### PR TITLE
Update cert-renewer and wpt-server dockerfiles

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,14 @@ on:
   pull_request:
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.10.4'
     - name: Install Python dependencies
       run: pip install pipenv && pipenv install --dev
     - name: flake8

--- a/cert-renewer.Dockerfile
+++ b/cert-renewer.Dockerfile
@@ -1,38 +1,39 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 # No interactive frontend during docker build
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 
-RUN apt-get -qqy update && \
-  apt-get -qqy install \
-    apt-transport-https \
-    curl \
-    software-properties-common && \
-  CLOUD_SDK_REPO="cloud-sdk-$(grep VERSION_CODENAME /etc/os-release | cut -d '=' -f 2)" && \
-  echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | \
-    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-    apt-key add - && \
-  apt-get -qqy update && \
-  apt-get -qqy install \
-    git \
-    google-cloud-sdk \
-    python3-pip
-
-# cryptography 2.1.4 is installed by default, but cryptography>=2.3 is required
-# by `PyOpenSSL` (a dependency of `certbot`)
-
-RUN git clone https://github.com/certbot/certbot --branch v0.35.1 && \
-  cd certbot && \
-  pip3 install --upgrade cryptography && \
-  python3 setup.py install && \
-  cd certbot-dns-google && \
-  python3 setup.py install
-
 ENV WPT_HOST=wpt.live \
   WPT_ALT_HOST=not-wpt.live \
   WPT_BUCKET=wpt-live
+
+# Pin the versions for repeatable builds
+# For ubuntu package versions, go to https://packages.ubuntu.com/
+#   Search for the package with the "jammy" distribution (aka 22.04) selected.
+# For Google Cloud, look under https://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages
+RUN apt-get -qqy update && \
+  apt-get -qqy install \
+    apt-transport-https=2.4.6 \
+    ca-certificates=20211016 \
+    curl=7.81.0-1ubuntu1.3 \
+    gnupg=2.2.27-3ubuntu2.1 \
+    python3=3.10.4-0ubuntu2 \
+    python3-dev=3.10.4-0ubuntu2 \
+    python3-pip=22.0.2+dfsg-1 && \
+  # https://cloud.google.com/storage/docs/gsutil_install
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    tee /usr/share/keyrings/cloud.google.gpg && \
+  apt-get -qqy update && \
+  apt-get -qqy install \
+    google-cloud-cli=396.0.0-0 && \
+  rm -rf /var/lib/apt/lists/* && apt-get clean
+
+# Instructions for certbot installation
+# https://certbot.eff.org/instructions?ws=other&os=pip
+RUN pip install certbot==1.29.0 certbot-dns-google==1.29.0
 
 COPY src/cert-store.sh /usr/local/bin/
 
@@ -43,7 +44,7 @@ COPY src/cert-store.sh /usr/local/bin/
 # >
 # > on the command line as well.
 #
-# https://certbot.eff.org/docs/install.html?highlight=wildcard
+# https://eff-certbot.readthedocs.io/en/stable/using.html?highlight=wildcard#dns-plugins
 
 CMD bash -c '\
   cert-store.sh fetch ${WPT_BUCKET} ${WPT_HOST}; \

--- a/wpt-server-tot.Dockerfile
+++ b/wpt-server-tot.Dockerfile
@@ -1,39 +1,51 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 # No interactive frontend during docker build
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 
+# Pin the versions for repeatable builds
+# For ubuntu package versions, go to https://packages.ubuntu.com/
+#   Search for the package with the "jammy" distribution (aka 22.04) selected.
+# For Google Cloud, look under https://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages
 RUN \
   apt-get -qqy update && \
   apt-get -qqy install \
-    curl \
-    gettext-base \
-    git \
-    gnupg \
-    locales \
-    python3 \
-    python3-pip \
-    supervisor \
-    tzdata
-
-RUN \
-  CLOUD_SDK_REPO="cloud-sdk-$(grep VERSION_CODENAME /etc/os-release | cut -d '=' -f 2)" && \
-  echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | \
+    apt-transport-https=2.4.6 \
+    ca-certificates=20211016 \
+    curl=7.81.0-1ubuntu1.3 \
+    gettext-base=0.21-4ubuntu4 \
+    git=1:2.34.1-1ubuntu1.4 \
+    gnupg=2.2.27-3ubuntu2.1 \
+    locales=2.35-0ubuntu3.1 \
+    python3=3.10.4-0ubuntu2 \
+    python3-dev=3.10.4-0ubuntu2 \
+    python3-pip=22.0.2+dfsg-1 \
+    python3-venv=3.10.4-0ubuntu2 \
+    supervisor=4.2.1-1ubuntu1 \
+    tzdata=2022a-0ubuntu1 && \
+  # https://cloud.google.com/storage/docs/gsutil_install
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
     tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    tee /usr/share/keyrings/cloud.google.gpg && \
   apt-get -qqy update && \
-  apt-get -qqy install google-cloud-sdk
+  apt-get -qqy install \
+    google-cloud-cli=396.0.0-0 && \
+  rm -rf /var/lib/apt/lists/* && apt-get clean
+
 
 ENV TZ "UTC"
 RUN echo "${TZ}" > /etc/timezone \
   && dpkg-reconfigure --frontend noninteractive tzdata
 
-# Set the locale
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+# Generate and set the locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LC_ALL=en_US.UTF-8 \
+  LANG=en_US.UTF-8 \
+  LANGUAGE=en_US:en
+RUN dpkg-reconfigure --frontend=noninteractive locales
 
 # Generate a self-signed TLS certificate so that the WPT server can be started
 # prior to the initial retrieval of the latest legitimate certificate.


### PR DESCRIPTION
Changes:
Switch to ubuntu:22.04 from ubuntu:18:04
This brings the python version from 3.6 to python 3.10.4
This should fix the "cannot import name 'TypedDict' error in #64
Pin the apt package versions for repeatable docker builds

Upgrade certbot version from 0.35.1 to 1.29.0 for cert-renewer

Was getting a locale warning after upgrading to bullseye. Changed
instructions in Dockerfile to fix the warning.

Update instructions for installing latest gcloud & gsutil cli

Fixes #64
Fixes #55 

---
Screenshots of it working locally

## cert-renewer

I forced the cert-renewer to renew the cert and it works

![image](https://user-images.githubusercontent.com/7788930/182896739-a5806228-4d1f-4f08-897b-92e1a2dafec4.png)

![image](https://user-images.githubusercontent.com/7788930/182896925-02e4bd47-7e80-4fe1-95de-cdfa6453c16e.png)

Checked the bucket and saw it was updated
![image](https://user-images.githubusercontent.com/7788930/182897108-f75f7d06-8d5c-4afd-88fa-c63811f55665.png)

## wpt-server
![image](https://user-images.githubusercontent.com/7788930/182890067-cb867ef0-21ed-477b-8806-a16b35beb9e3.png)

![image](https://user-images.githubusercontent.com/7788930/182890131-f4e065e0-14a5-439b-b8fc-e74bb84ca42b.png)


System is able to detect when new certs are available and downloads them like before
![image](https://user-images.githubusercontent.com/7788930/182905607-cef45191-790c-4860-923e-4aeeada672a3.png)

![image](https://user-images.githubusercontent.com/7788930/182907367-c4aa8350-358a-4841-9846-deb04aadf11d.png)

System is able to see new updates to wpt like before

![image](https://user-images.githubusercontent.com/7788930/182920289-5b1e59b1-5b95-464a-81c3-654eaae4eac0.png)

![image](https://user-images.githubusercontent.com/7788930/182920345-19ad223b-cbd3-4e53-a7c7-9f2ac8683326.png)

