### PR TITLE
Update the terraform state after building docker images

### DIFF
--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.2.5",
-  "serial": 35,
+  "serial": 42,
   "lineage": "3e752c40-46ae-cf3a-9a1d-073d2251df8c",
   "outputs": {
     "wpt-live-address": {
@@ -109,8 +109,8 @@
             ],
             "query": null,
             "result": {
-              "identifier": "sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5",
-              "time_created": "1570479055243"
+              "identifier": "sha256:cf3bd94c854d9eb43cec6af9d38e68f4882d8bd7ad064f71d52f04d1995b1ff3",
+              "time_created": "1659629001935"
             },
             "working_dir": null
           },
@@ -811,7 +811,7 @@
             "auto_healing_policies": [],
             "base_instance_name": "wpt-tot-cert-renewers",
             "description": "compute VM Instance Group",
-            "fingerprint": "s-FAcrVmWaM=",
+            "fingerprint": "Cv7c4xciZn4=",
             "id": "wpt-live/us-central1-b/wpt-tot-cert-renewers",
             "instance_group": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-cert-renewers",
             "name": "wpt-tot-cert-renewers",
@@ -827,7 +827,7 @@
             "stateful_disk": [],
             "status": [
               {
-                "is_stable": true,
+                "is_stable": false,
                 "stateful": [
                   {
                     "has_stateful_config": false,
@@ -840,7 +840,7 @@
                 ],
                 "version_target": [
                   {
-                    "is_reached": true
+                    "is_reached": false
                   }
                 ]
               }
@@ -866,7 +866,7 @@
             ],
             "version": [
               {
-                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906183108590000000001",
+                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906194131963800000002",
                 "name": "",
                 "target_size": []
               }
@@ -905,7 +905,7 @@
             ],
             "base_instance_name": "wpt-tot-wpt-servers",
             "description": "compute VM Instance Group",
-            "fingerprint": "47_giIENkps=",
+            "fingerprint": "1wRfSfZ0h6Y=",
             "id": "wpt-live/us-central1-b/wpt-tot-wpt-servers",
             "instance_group": "https://www.googleapis.com/compute/v1/projects/wpt-live/zones/us-central1-b/instanceGroups/wpt-tot-wpt-servers",
             "name": "wpt-tot-wpt-servers",
@@ -958,7 +958,7 @@
                 ],
                 "version_target": [
                   {
-                    "is_reached": true
+                    "is_reached": false
                   }
                 ]
               }
@@ -986,7 +986,7 @@
             ],
             "version": [
               {
-                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906183108590200000002",
+                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906194131960800000001",
                 "name": "wpt-tot-wpt-servers-default",
                 "target_size": []
               }
@@ -1001,7 +1001,6 @@
             "google_compute_network.default",
             "google_compute_subnetwork.default",
             "module.wpt-live.google_compute_health_check.wpt_health_check",
-            "module.wpt-live.google_compute_http_health_check.default",
             "module.wpt-live.google_compute_instance_template.wpt_server",
             "module.wpt-live.google_compute_target_pool.default",
             "module.wpt-live.module.wpt-server-container.data.google_compute_image.coreos",
@@ -1022,7 +1021,7 @@
           "attributes": {
             "advanced_machine_features": [],
             "can_ip_forward": false,
-            "confidential_instance_config": [],
+            "confidential_instance_config": null,
             "description": "",
             "disk": [
               {
@@ -1034,31 +1033,31 @@
                 "disk_size_gb": 0,
                 "disk_type": "pd-ssd",
                 "interface": "SCSI",
-                "labels": {},
+                "labels": null,
                 "mode": "READ_WRITE",
-                "resource_policies": [],
+                "resource_policies": null,
                 "source": "",
                 "source_image": "projects/cos-cloud/global/images/cos-stable-97-16919-103-33",
                 "type": "PERSISTENT"
               }
             ],
             "guest_accelerator": [],
-            "id": "projects/wpt-live/global/instanceTemplates/default-20220906183108590000000001",
+            "id": "projects/wpt-live/global/instanceTemplates/default-20220906194131963800000002",
             "instance_description": "",
             "labels": {
               "container-vm": "cos-stable-97-16919-103-33"
             },
             "machine_type": "f1-micro",
             "metadata": {
-              "gce-container-declaration": "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"WPT_HOST\"\n      \"value\": \"wpt.live\"\n    - \"name\": \"WPT_ALT_HOST\"\n      \"value\": \"not-wpt.live\"\n    - \"name\": \"WPT_BUCKET\"\n      \"value\": \"wpt-tot-certificates\"\n    \"image\": \"gcr.io/wpt-live/wpt-live-cert-renewer@sha256:5b3c0a3a2b0d7e2a0e1c0303874d09bb3214aa93dec55ac245cf1c81e7d117d5\"\n  \"restartPolicy\": \"Always\"\n  \"volumes\": []\n",
+              "gce-container-declaration": "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"WPT_HOST\"\n      \"value\": \"wpt.live\"\n    - \"name\": \"WPT_ALT_HOST\"\n      \"value\": \"not-wpt.live\"\n    - \"name\": \"WPT_BUCKET\"\n      \"value\": \"wpt-tot-certificates\"\n    \"image\": \"gcr.io/wpt-live/wpt-live-cert-renewer@sha256:cf3bd94c854d9eb43cec6af9d38e68f4882d8bd7ad064f71d52f04d1995b1ff3\"\n  \"restartPolicy\": \"Always\"\n  \"volumes\": []\n",
               "google-logging-enabled": "true",
               "startup-script": "",
               "tf_depends_id": ""
             },
-            "metadata_fingerprint": "1ZNkrK2-PJQ=",
+            "metadata_fingerprint": "f0mMYijrpbo=",
             "metadata_startup_script": null,
             "min_cpu_platform": "",
-            "name": "default-20220906183108590000000001",
+            "name": "default-20220906194131963800000002",
             "name_prefix": "default-",
             "network_interface": [
               {
@@ -1096,7 +1095,7 @@
                 "provisioning_model": "STANDARD"
               }
             ],
-            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906183108590000000001",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906194131963800000002",
             "service_account": [
               {
                 "email": "default",
@@ -1137,7 +1136,7 @@
           "attributes": {
             "advanced_machine_features": [],
             "can_ip_forward": false,
-            "confidential_instance_config": [],
+            "confidential_instance_config": null,
             "description": "",
             "disk": [
               {
@@ -1149,31 +1148,31 @@
                 "disk_size_gb": 0,
                 "disk_type": "pd-ssd",
                 "interface": "SCSI",
-                "labels": {},
+                "labels": null,
                 "mode": "READ_WRITE",
-                "resource_policies": [],
+                "resource_policies": null,
                 "source": "",
                 "source_image": "projects/cos-cloud/global/images/cos-stable-97-16919-103-33",
                 "type": "PERSISTENT"
               }
             ],
             "guest_accelerator": [],
-            "id": "projects/wpt-live/global/instanceTemplates/default-20220906183108590200000002",
+            "id": "projects/wpt-live/global/instanceTemplates/default-20220906194131960800000001",
             "instance_description": "",
             "labels": {
               "container-vm": "cos-stable-97-16919-103-33"
             },
             "machine_type": "e2-medium",
             "metadata": {
-              "gce-container-declaration": "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"WPT_HOST\"\n      \"value\": \"wpt.live\"\n    - \"name\": \"WPT_ALT_HOST\"\n      \"value\": \"not-wpt.live\"\n    - \"name\": \"WPT_BUCKET\"\n      \"value\": \"wpt-tot-certificates\"\n    \"image\": \"gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe\"\n  \"restartPolicy\": \"Always\"\n  \"volumes\": []\n",
+              "gce-container-declaration": "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"WPT_HOST\"\n      \"value\": \"wpt.live\"\n    - \"name\": \"WPT_ALT_HOST\"\n      \"value\": \"not-wpt.live\"\n    - \"name\": \"WPT_BUCKET\"\n      \"value\": \"wpt-tot-certificates\"\n    \"image\": \"gcr.io/wpt-live/wpt-live-wpt-server-tot@sha256:60bb26e3ea8b90c8aa2f645a710a1978a9014715026b244e1c158a4c74f3bd98\"\n  \"restartPolicy\": \"Always\"\n  \"volumes\": []\n",
               "google-logging-enabled": "true",
               "startup-script": "",
               "tf_depends_id": ""
             },
-            "metadata_fingerprint": "D4kxKCoOqp8=",
+            "metadata_fingerprint": "0NBhS1bTNQE=",
             "metadata_startup_script": null,
             "min_cpu_platform": "",
-            "name": "default-20220906183108590200000002",
+            "name": "default-20220906194131960800000001",
             "name_prefix": "default-",
             "network_interface": [
               {
@@ -1211,7 +1210,7 @@
                 "provisioning_model": "STANDARD"
               }
             ],
-            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906183108590200000002",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live/global/instanceTemplates/default-20220906194131960800000001",
             "service_account": [
               {
                 "email": "default",
@@ -1259,6 +1258,7 @@
             ],
             "id": "wpt-tot-load-balancing",
             "instances": [
+              "us-central1-b/wpt-tot-wpt-servers-cnc0",
               "us-central1-b/wpt-tot-wpt-servers-h0d9"
             ],
             "name": "wpt-tot-load-balancing",
@@ -1593,8 +1593,8 @@
             ],
             "query": null,
             "result": {
-              "identifier": "sha256:5d7a3d7a5ca0ba4ca7f6e56ad62aa6342c9ab92d41eea24cc6ce4a9b1e2a6afe",
-              "time_created": "1610631609527"
+              "identifier": "sha256:60bb26e3ea8b90c8aa2f645a710a1978a9014715026b244e1c158a4c74f3bd98",
+              "time_created": "1659627204435"
             },
             "working_dir": null
           },


### PR DESCRIPTION
Following the instructions for deploying in the README.
terraform apply deployed the new docker images.

This was kept separate from the OS updates in #60. That updated the OS
version image. (Wanted to minimize the amount of changes at once) This PR updated the docker images for cert renewers and the wpt.live server

All of these changes were generated automatically by terraform upon
apply

The reason why there was no terraform configuration change and only terraform state changes: The terraform just pulls the latest docker image in the registry. (After doing the instructions in the README, it pushes new versions to the docker registry) We might want to pin that to certain versions in case we need to do a rollback.